### PR TITLE
[FIX] Call interpolated query cost function

### DIFF
--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -147,7 +147,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
     for (size_t t_max = 64; t_max <= config.t_max; t_max *= 2)
         potential_t_max.insert(t_max);
 
-    // Additionally, add the t_max that is closest to the sqrt() of the number of 
+    // Additionally, add the t_max that is closest to the sqrt() of the number of
     // user bins, as it is expected to evenly spread bins and may perform well.
     size_t const user_bin_count{std::ranges::size(data.kmer_counts)};
     size_t const sqrt_t_max{next_multiple_of_64(std::ceil(std::sqrt(user_bin_count)))};
@@ -185,7 +185,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
         if (config.output_statistics)
         {
             std::cout << "#T_Max:" << t_max << '\n'
-                      << "#C_{T_Max}:" << chopper::layout::ibf_query_cost::exact(t_max) << '\n'
+                      << "#C_{T_Max}:" << chopper::layout::ibf_query_cost::interpolated(t_max) << '\n'
                       << "#relative expected HIBF query time cost (l):" << expected_HIBF_query_cost << '\n' /*relative to a 64 bin IBF*/
                       << "#relative HIBF memory usage (m):" << relative_memory_size << '\n' /*relative to the 64 T_Max HIBF*/
                       << "#l*m:" << query_time_memory_usage_prod << '\n';
@@ -193,7 +193,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
         else
         {
             std::cout << t_max << '\t'
-                      << chopper::layout::ibf_query_cost::exact(t_max) << '\t'
+                      << chopper::layout::ibf_query_cost::interpolated(t_max) << '\t'
                       << expected_HIBF_query_cost << '\n';
         }
 


### PR DESCRIPTION
We must use the interpolation here, because there is no exact data for the t_max ~ sqrt(#UBs) case. For the other values it won't make a difference, because the interpolation checks whether there is exact data available.