### PR TITLE
[MISC] Collect estimated query costs in hibf_statistics.

### DIFF
--- a/include/chopper/layout/configuration.hpp
+++ b/include/chopper/layout/configuration.hpp
@@ -2,8 +2,6 @@
 
 #include <seqan3/std/filesystem>
 
-#include <chopper/layout/previous_level.hpp>
-
 namespace chopper::layout
 {
 

--- a/include/chopper/layout/data_store.hpp
+++ b/include/chopper/layout/data_store.hpp
@@ -35,9 +35,6 @@ struct data_store
     //!\brief An object starting at the top level IBF to collecting statistics about the HIBF on the way.
     hibf_statistics::level * stats{nullptr};
 
-    //!\brief Keeps track of the estimated query cost in the resulting HIBF.
-    double total_query_cost{0.0};
-
     //!\brief Precompute f_h factors that adjust the split bin size to prevent FPR inflation due to multiple testing.
     void compute_fp_correction(double const fp_rate, size_t const num_hash_functions, size_t const requested_max_tb)
     {

--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -38,10 +38,11 @@ public:
     //!\brief A representation of an IBF level that gathers information about bins in an IBF.
     struct level
     {
+        //!\brief The bins of the current IBF level. May be split or merged bins.
         std::vector<bin> bins;
 
-        // if the level represents some lower level IBF, this tracks the estimated query costs so far.
-        double previous_query_cost{0.0};
+        //!\brief The query cost to arrive at this IBF (updated before backtracking respective DP).
+        double current_query_cost{0.0};
     };
 
     //!\brief The kind of bin that is stored.

--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -74,11 +74,17 @@ public:
         }
     };
 
+    //!\brief Gather all statistics to have all members ready.
+    void finalize()
+    {
+        gather_statistics(top_level_ibf, 0);
+    }
+
     //!\brief Prints a tab-separated summary of the statistics of this HIBF to the command line.
     void print_summary()
     {
         if (summaries.empty())
-            gather_statistics(top_level_ibf, 0);
+            finalize();
 
         std::cout << std::fixed << std::setprecision(2);
 

--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -39,6 +39,9 @@ public:
     struct level
     {
         std::vector<bin> bins;
+
+        // if the level represents some lower level IBF, this tracks the estimated query costs so far.
+        double previous_query_cost{0.0};
     };
 
     //!\brief The kind of bin that is stored.

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -301,6 +301,7 @@ private:
 
         // The cost for querying `num_technical_bins` bins.
         double const interpolated_cost{ibf_query_cost::interpolated(num_technical_bins)};
+        data->stats->current_query_cost += interpolated_cost;
 
         // backtracking starts at the bottom right corner:
         size_t trace_i = num_technical_bins - 1;
@@ -356,7 +357,7 @@ private:
                                                kmer_count_per_bin,
                                                1ul,
                                                number_of_bins,
-                                               (data->stats->previous_query_cost + interpolated_cost) * kmer_count);
+                                               data->stats->current_query_cost * kmer_count);
 
                 if (!config.debug)
                     print_result_line(*data, trace_j, bin_id, number_of_bins);
@@ -416,7 +417,7 @@ private:
                                            average_bin_size,
                                            1ul,
                                            number_of_tbs,
-                                           (data->stats->previous_query_cost + interpolated_cost) * kmer_count);
+                                           data->stats->current_query_cost * kmer_count);
 
             if (!config.debug)
                 print_result_line(*data, 0, bin_id, number_of_tbs);
@@ -471,7 +472,7 @@ private:
         hibf_statistics::bin & bin_stats = data->stats->bins.emplace_back(hibf_statistics::bin_kind::merged,
                                             cardinality, num_contained_ubs, 1ul);
         libf_data.stats = &bin_stats.child_level;
-        libf_data.stats->previous_query_cost += ibf_query_cost::interpolated(num_technical_bins);
+        libf_data.stats->current_query_cost = data->stats->current_query_cost;
 
         // now do the binning for the low-level IBF:
         size_t const lower_max_bin = add_lower_level(libf_data);

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -356,7 +356,7 @@ private:
                                                kmer_count_per_bin,
                                                1ul,
                                                number_of_bins,
-                                               (data->previous.cost + interpolated_cost) * kmer_count);
+                                               (data->stats->previous_query_cost + interpolated_cost) * kmer_count);
 
                 if (!config.debug)
                     print_result_line(*data, trace_j, bin_id, number_of_bins);
@@ -416,7 +416,7 @@ private:
                                            average_bin_size,
                                            1ul,
                                            number_of_tbs,
-                                           (data->previous.cost + interpolated_cost) * kmer_count);
+                                           (data->stats->previous_query_cost + interpolated_cost) * kmer_count);
 
             if (!config.debug)
                 print_result_line(*data, 0, bin_id, number_of_tbs);
@@ -471,6 +471,7 @@ private:
         hibf_statistics::bin & bin_stats = data->stats->bins.emplace_back(hibf_statistics::bin_kind::merged,
                                             cardinality, num_contained_ubs, 1ul);
         libf_data.stats = &bin_stats.child_level;
+        libf_data.stats->previous_query_cost += ibf_query_cost::interpolated(num_technical_bins);
 
         // now do the binning for the low-level IBF:
         size_t const lower_max_bin = add_lower_level(libf_data);
@@ -484,8 +485,7 @@ private:
 
         libf_data.previous = data->previous;
         libf_data.previous.bin_indices += (is_top_level ? "" : ";") + std::to_string(bin_id);
-        libf_data.previous.num_of_bins  += (is_top_level ? "" : ";") + std::string{"1"};
-        libf_data.previous.cost += ibf_query_cost::interpolated(num_technical_bins); // needed for statistics
+        libf_data.previous.num_of_bins += (is_top_level ? "" : ";") + std::string{"1"};
     }
 
     void update_debug_libf_data(data_store & libf_data, size_t const kmer_count, size_t const optimal_score) const

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -485,7 +485,7 @@ private:
         libf_data.previous = data->previous;
         libf_data.previous.bin_indices += (is_top_level ? "" : ";") + std::to_string(bin_id);
         libf_data.previous.num_of_bins  += (is_top_level ? "" : ";") + std::string{"1"};
-        libf_data.previous.cost += ibf_query_cost::interpolated(num_technical_bins);
+        libf_data.previous.cost += ibf_query_cost::interpolated(num_technical_bins); // needed for statistics
     }
 
     void update_debug_libf_data(data_store & libf_data, size_t const kmer_count, size_t const optimal_score) const
@@ -500,22 +500,17 @@ private:
 
     size_t add_lower_level(data_store & libf_data) const
     {
-        size_t merged_max_bin_id;
-
         // now do the binning for the low-level IBF:
         if (libf_data.kmer_counts.size() > config.t_max)
         {
             // recursively call hierarchical binning if there are still too many UBs
-            merged_max_bin_id = hierarchical_binning{libf_data, config}.execute();
+            return hierarchical_binning{libf_data, config}.execute(); // return id of maximum technical bin
         }
         else
         {
             // use simple binning to distribute remaining UBs
-            simple_binning algo{libf_data, 0, config.debug};
-            merged_max_bin_id = algo.execute();
+            return simple_binning{libf_data, 0, config.debug}.execute();  // return id of maximum technical bin
         }
-
-        return merged_max_bin_id;
     }
 
     void update_max_id(size_t & max_id, size_t & max_size, size_t const new_id, size_t const new_size) const

--- a/include/chopper/layout/previous_level.hpp
+++ b/include/chopper/layout/previous_level.hpp
@@ -15,7 +15,6 @@ struct previous_level
     std::string optimal_score;
     std::string correction;
     std::string tmax;
-    double cost{};
 
     bool empty() const
     {

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -9,6 +9,7 @@
 
 #include <chopper/helper.hpp>
 #include <chopper/layout/data_store.hpp>
+#include <chopper/layout/ibf_query_cost.hpp>
 #include <chopper/layout/previous_level.hpp>
 #include <chopper/layout/print_matrix.hpp>
 #include <chopper/layout/print_result_line.hpp>
@@ -222,7 +223,11 @@ public:
             size_t const kmer_count_per_bin = (kmer_count + number_of_bins - 1) / number_of_bins; // round up
 
             // add split bin to ibf statistics
-            data->stats->bins.emplace_back(hibf_statistics::bin_kind::split, kmer_count_per_bin, 1ul, number_of_bins);
+            data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
+                                           kmer_count_per_bin,
+                                           1ul,
+                                           number_of_bins,
+                                           (data->previous.cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
 
             if (!debug)
                 print_result_line(*data, trace_j, bin_id, number_of_bins);
@@ -245,7 +250,11 @@ public:
         size_t const kmer_count_per_bin =  (kmer_count + trace_i - 1) / trace_i;
 
         // add split bin to ibf statistics
-        data->stats->bins.emplace_back(hibf_statistics::bin_kind::split, kmer_count_per_bin, 1ul, trace_i);
+        data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
+                                       kmer_count_per_bin,
+                                       1ul,
+                                       trace_i,
+                                       (data->previous.cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
 
         if (kmer_count_per_bin > max_size)
         {

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -227,7 +227,7 @@ public:
                                            kmer_count_per_bin,
                                            1ul,
                                            number_of_bins,
-                                           (data->previous.cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
+                                           (data->stats->previous_query_cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
 
             if (!debug)
                 print_result_line(*data, trace_j, bin_id, number_of_bins);
@@ -254,7 +254,7 @@ public:
                                        kmer_count_per_bin,
                                        1ul,
                                        trace_i,
-                                       (data->previous.cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
+                                       (data->stats->previous_query_cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
 
         if (kmer_count_per_bin > max_size)
         {

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -206,6 +206,8 @@ public:
         // print_matrix(trace, num_technical_bins, num_user_bins, std::numeric_limits<size_t>::max());
 
         // backtracking
+        data->stats->current_query_cost += ibf_query_cost::interpolated(num_technical_bins);
+
         size_t trace_i = num_technical_bins - 1;
         size_t trace_j = num_user_bins - 1;
 
@@ -227,7 +229,7 @@ public:
                                            kmer_count_per_bin,
                                            1ul,
                                            number_of_bins,
-                                           (data->stats->previous_query_cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
+                                           data->stats->current_query_cost * kmer_count);
 
             if (!debug)
                 print_result_line(*data, trace_j, bin_id, number_of_bins);
@@ -254,7 +256,7 @@ public:
                                        kmer_count_per_bin,
                                        1ul,
                                        trace_i,
-                                       (data->stats->previous_query_cost + ibf_query_cost::interpolated(num_technical_bins)) * kmer_count);
+                                       data->stats->current_query_cost * kmer_count);
 
         if (kmer_count_per_bin > max_size)
         {

--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -169,12 +169,13 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
 
         chopper::layout::hibf_statistics global_stats{config, data.fp_correction};
         data.stats = &global_stats.top_level_ibf;
-        data.total_query_cost = 0.0;
 
         // execute the actual algorithm
         size_t const max_hibf_id_tmp = chopper::layout::hierarchical_binning{data, config}.execute();
 
-        double const expected_HIBF_query_cost = data.total_query_cost / total_kmer_count;
+        global_stats.finalize();
+
+        double const expected_HIBF_query_cost = global_stats.total_query_cost / total_kmer_count;
 
         if (!t_max_64_memory)
             t_max_64_memory = global_stats.total_hibf_size_in_byte();


### PR DESCRIPTION
Now that we understood how the query cost is gathered, I think this refactoring makes it much more easy to understand since the cost is only collected when a split bin is added. 
In the end everything is added up. Done.

Review commit by commit for a better understanding of the step wise refactoring.