### PR TITLE
[FEATURE] Output config in layout file.

### DIFF
--- a/include/chopper/cereal/path.hpp
+++ b/include/chopper/cereal/path.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <filesystem>
+
+#include <cereal/cereal.hpp>
+
+namespace cereal
+{
+
+template <typename archive_t>
+void CEREAL_SAVE_FUNCTION_NAME(archive_t & archive, std::filesystem::path const & path)
+{
+    std::string const str{path.string()};
+    archive(str);
+}
+
+template <typename archive_t>
+void CEREAL_LOAD_FUNCTION_NAME(archive_t & archive, std::filesystem::path & path)
+{
+    std::string str;
+    archive(str);
+    path.assign(str);
+}
+
+} // namespace cereal

--- a/include/chopper/count/configuration.hpp
+++ b/include/chopper/count/configuration.hpp
@@ -13,7 +13,7 @@ struct configuration
     std::filesystem::path count_filename{};   // set internally
     std::filesystem::path sketch_directory{}; // set internally
     size_t column_index_to_cluster{1u};
-    size_t num_threads{1u};
+    size_t threads{1u};
     uint8_t k{19};
     uint8_t sketch_bits{12};
     bool disable_sketch_output{false};

--- a/include/chopper/count/count_kmers.hpp
+++ b/include/chopper/count/count_kmers.hpp
@@ -47,7 +47,7 @@ inline void count_kmers(robin_hood::unordered_map<std::string, std::vector<std::
     for (auto const & cluster : filename_clusters)
         cluster_vector.emplace_back(cluster.first, cluster.second);
 
-    #pragma omp parallel for schedule(static) num_threads(config.num_threads)
+    #pragma omp parallel for schedule(static) num_threads(config.threads)
     for (size_t i = 0; i < cluster_vector.size(); ++i)
     {
         chopper::sketch::hyperloglog sketch(config.sketch_bits);

--- a/include/chopper/layout/arrange_user_bins.hpp
+++ b/include/chopper/layout/arrange_user_bins.hpp
@@ -18,10 +18,10 @@ inline void arrange_user_bins(data_store & data, configuration const & config)
         if (config.estimate_union)
         {
             bin_sequence.read_hll_files(config.sketch_directory);
-            if (config.rearrange_bins)
-                bin_sequence.rearrange_bins(config.max_ratio, config.num_threads);
+            if (config.rearrange_user_bins)
+                bin_sequence.rearrange_bins(config.max_rearrangement_ratio, config.threads);
 
-            bin_sequence.estimate_interval_unions(data.union_estimates, config.num_threads);
+            bin_sequence.estimate_interval_unions(data.union_estimates, config.threads);
         }
 
         data.user_bins_arranged = true;

--- a/include/chopper/layout/configuration.hpp
+++ b/include/chopper/layout/configuration.hpp
@@ -2,21 +2,26 @@
 
 #include <filesystem>
 
+#include <cereal/cereal.hpp>
+#include <cereal/types/vector.hpp>
+#include <cereal/types/string.hpp>
+#include <chopper/cereal/path.hpp>
+
 namespace chopper::layout
 {
 
 struct configuration
 {
-    std::string input_prefix; // provided by user
-    std::filesystem::path count_filename;   // internally set
-    std::filesystem::path sketch_directory; // internally set
+    std::string input_prefix{}; // provided by user
+    std::filesystem::path count_filename{};   // internally set
+    std::filesystem::path sketch_directory{}; // internally set
     std::filesystem::path output_filename{"binning.out"};
-    uint16_t t_max{64};
+    uint16_t tmax{64};
     int8_t aggregate_by_column{-1};
     //!\brief The number of hash functions for the IBFs.
     size_t num_hash_functions{2};
     //!\brief The desired false positive rate of the IBFs.
-    double fp_rate{0.05};
+    double false_positive_rate{0.05};
     /*\brief A scaling factor to influence the amount of merged bins produced by the algorithm.
      *
      * The higher alpha, the more weight is added artificially to the low level IBFs and thus the optimal
@@ -24,19 +29,46 @@ struct configuration
      */
     double alpha{1.2};
     //!\brief The maximal cardinality ratio in the clustering intervals.
-    double max_ratio{0.5};
+    double max_rearrangement_ratio{0.5};
     //!\brief The number of threads to use to compute merged HLL sketches.
-    size_t num_threads{1u};
+    size_t threads{1u};
     //!\brief Whether to estimate the union of kmer sets to possibly improve the binning or not.
     bool estimate_union{false};
     //!\brief Whether to do a second sorting of the bins which takes into account similarity or not.
-    bool rearrange_bins{false};
+    bool rearrange_user_bins{false};
     //!\brief Whether the program should determine the best number of IBF bins by doing multiple binning runs
     bool determine_best_tmax{false};
     //!\brief Whether the programm should compute all binnings up to the given t_max
     bool force_all_binnings{false};
     bool output_statistics{false};
     bool debug{false};
+
+private:
+    friend class cereal::access;
+
+    template <typename archive_t>
+    void serialize(archive_t & archive)
+    {
+        uint32_t const version{1};
+
+        archive(CEREAL_NVP(version));
+        archive(CEREAL_NVP(input_prefix));
+        archive(CEREAL_NVP(count_filename));
+        archive(CEREAL_NVP(sketch_directory));
+        archive(CEREAL_NVP(output_filename));
+        archive(CEREAL_NVP(tmax));
+        // archive(CEREAL_NVP(aggregate_by_column));
+        archive(CEREAL_NVP(num_hash_functions));
+        archive(CEREAL_NVP(false_positive_rate));
+        archive(CEREAL_NVP(alpha));
+        archive(CEREAL_NVP(max_rearrangement_ratio));
+        archive(CEREAL_NVP(threads));
+        archive(CEREAL_NVP(estimate_union));
+        archive(CEREAL_NVP(rearrange_user_bins));
+        archive(CEREAL_NVP(determine_best_tmax));
+        archive(CEREAL_NVP(force_all_binnings));
+        archive(CEREAL_NVP(output_statistics));
+    }
 };
 
 } // namespace chopper::layout

--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -230,7 +230,7 @@ private:
     size_t compute_bin_size(size_t const number_of_kmers_to_be_stored) const
     {
         return std::ceil( - static_cast<double>(number_of_kmers_to_be_stored * config.num_hash_functions) /
-               std::log(1 - std::exp(std::log(config.fp_rate) / config.num_hash_functions)));
+               std::log(1 - std::exp(std::log(config.false_positive_rate) / config.num_hash_functions)));
     }
 
     /*!\brief Compute the Bloom Filter size from `number_of_kmers_to_be_stored` and

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -46,7 +46,7 @@ public:
         config{config_},
         data{std::addressof(data_)},
         num_user_bins{data->kmer_counts.size()},
-        num_technical_bins{data->previous.empty() ? config.t_max : needed_technical_bins(num_user_bins)}
+        num_technical_bins{data->previous.empty() ? config.tmax : needed_technical_bins(num_user_bins)}
     {
         assert(data != nullptr);
         assert(data->output_buffer != nullptr);
@@ -103,7 +103,7 @@ private:
      */
     [[nodiscard]] size_t needed_technical_bins(size_t const requested_num_ub) const
     {
-        return std::min<size_t>(next_multiple_of_64(requested_num_ub), config.t_max);
+        return std::min<size_t>(next_multiple_of_64(requested_num_ub), config.tmax);
     }
 
     /*!\brief Returns the maximum number of needed levels when merging `num_ubs_in_merge` many user bins.
@@ -300,7 +300,7 @@ private:
         }
 
         // The cost for querying `num_technical_bins` bins.
-        double const interpolated_cost{ibf_query_cost::interpolated(num_technical_bins, config.fp_rate)};
+        double const interpolated_cost{ibf_query_cost::interpolated(num_technical_bins, config.false_positive_rate)};
         data->stats->current_query_cost += interpolated_cost;
 
         // backtracking starts at the bottom right corner:
@@ -503,7 +503,7 @@ private:
     size_t add_lower_level(data_store & libf_data) const
     {
         // now do the binning for the low-level IBF:
-        if (libf_data.kmer_counts.size() > config.t_max)
+        if (libf_data.kmer_counts.size() > config.tmax)
         {
             // recursively call hierarchical binning if there are still too many UBs
             return hierarchical_binning{libf_data, config}.execute(); // return id of maximum technical bin

--- a/include/chopper/layout/output.hpp
+++ b/include/chopper/layout/output.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cereal/archives/json.hpp>
+
+#include <chopper/layout/configuration.hpp>
+#include <chopper/prefixes.hpp>
+
+namespace chopper::layout
+{
+
+inline void write_config_to(configuration const & config, std::ostream & stream)
+{
+    // write json file to temprorary string stream with cereal
+    std::stringstream config_stream{};
+    cereal::JSONOutputArchive output(config_stream); // stream to cout
+    output(cereal::make_nvp("config", config));
+
+    // write config
+    stream << prefix::header << prefix::header_config << "CONFIG:\n";
+    std::string line;
+    while (std::getline(config_stream, line, '\n'))
+        stream << prefix::header << prefix::header_config << line << '\n';
+    stream << prefix::header << prefix::header_config << "}\n" // last closing bracket isn't written by loop above
+           << prefix::header << prefix::header_config << "ENDCONFIG\n";
+}
+
+inline void write_layout_header_to(configuration const & config, size_t const max_hibf_id, std::string_view const header, std::ostream & stream)
+{
+    write_config_to(config, stream);
+    stream << prefix::header << prefix::high_level << " max_bin_id:" << max_hibf_id << '\n';
+    stream << header;
+}
+
+} // namespace chopper::layout

--- a/include/chopper/prefixes.hpp
+++ b/include/chopper/prefixes.hpp
@@ -9,6 +9,8 @@ constexpr std::string_view chopper{"chopper"};
 
 constexpr std::string_view header{"#"};
 
+constexpr std::string_view header_config{"#"};
+
 constexpr std::string_view high_level{"HIGH_LEVEL_IBF"};
 
 constexpr std::string_view merged_bin{"MERGED_BIN"};

--- a/src/chopper_count.cpp
+++ b/src/chopper_count.cpp
@@ -48,7 +48,7 @@ void initialize_argument_parser(seqan3::argument_parser & parser, chopper::count
                       "the default prefix " + std::string{prefix::chopper} + " is appended.",
                       seqan3::option_spec::required);
 
-    parser.add_option(config.num_threads,
+    parser.add_option(config.threads,
                       '\0', "threads",
                       "The number of threads to be used for parallel processing.");
 

--- a/test/api/count/count_kmers_test.cpp
+++ b/test/api/count/count_kmers_test.cpp
@@ -12,7 +12,7 @@ TEST(count_kmers_test, small_example)
 
     chopper::count::configuration config;
     config.k = 15;
-    config.num_threads = 1;
+    config.threads = 1;
     config.output_prefix = output_prefix.get_path().string();
     chopper::detail::apply_prefix(config.output_prefix, config.count_filename, config.sketch_directory);
 
@@ -43,7 +43,7 @@ TEST(count_kmers_test, small_example_parallel_2_threads)
 
     chopper::count::configuration config;
     config.k = 15;
-    config.num_threads = 2;
+    config.threads = 2;
     config.output_prefix = output_prefix.get_path().string();
     chopper::detail::apply_prefix(config.output_prefix, config.count_filename, config.sketch_directory);
 

--- a/test/api/layout/execute_layout_test.cpp
+++ b/test/api/layout/execute_layout_test.cpp
@@ -29,7 +29,7 @@ TEST(execute_test, few_ubs)
     char const * const argv[] = {"./chopper-layout",
                                  "--tmax", "64",
                                  "--input-prefix", input_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str()};
+                                 "--output-filename", layout_file.get_path().c_str()};
     int const argc = sizeof(argv) / sizeof(*argv);
 
     seqan3::argument_parser layout_parser{"chopper-layout", argc, argv, seqan3::update_notifications::off};
@@ -37,6 +37,34 @@ TEST(execute_test, few_ubs)
 
     std::string const expected_file
     {
+        "##CONFIG:\n"
+        "##{\n"
+        "##    \"config\": {\n"
+        "##        \"version\": 1,\n"
+        "##        \"input_prefix\": \"" + input_prefix.get_path().string() + "\",\n"
+        "##        \"count_filename\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + ".count\"\n"
+        "##        },\n"
+        "##        \"sketch_directory\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + "_sketches\"\n"
+        "##        },\n"
+        "##        \"output_filename\": {\n"
+        "##            \"value0\": \"" + layout_file.get_path().string() + "\"\n"
+        "##        },\n"
+        "##        \"tmax\": 64,\n"
+        "##        \"num_hash_functions\": 2,\n"
+        "##        \"false_positive_rate\": 0.05,\n"
+        "##        \"alpha\": 1.2,\n"
+        "##        \"max_rearrangement_ratio\": 0.5,\n"
+        "##        \"threads\": 1,\n"
+        "##        \"estimate_union\": false,\n"
+        "##        \"rearrange_user_bins\": false,\n"
+        "##        \"determine_best_tmax\": false,\n"
+        "##        \"force_all_binnings\": false,\n"
+        "##        \"output_statistics\": false\n"
+        "##    }\n"
+        "##}\n"
+        "##ENDCONFIG\n"
         "#HIGH_LEVEL_IBF max_bin_id:6\n"
         "#FILES\tBIN_INDICES\tNUMBER_OF_BINS\n"
         "seq7\t0\t6\n"
@@ -50,7 +78,7 @@ TEST(execute_test, few_ubs)
     };
     std::string const actual_file{string_from_file(layout_file.get_path())};
 
-    EXPECT_EQ(actual_file, expected_file);
+    EXPECT_EQ(actual_file, expected_file) << actual_file;
 }
 
 TEST(execute_test, few_ubs_debug)
@@ -73,7 +101,7 @@ TEST(execute_test, few_ubs_debug)
     char const * const argv[] = {"./chopper-layout",
                                  "--tmax", "64",
                                  "--input-prefix", input_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str(),
+                                 "--output-filename", layout_file.get_path().c_str(),
                                  "--debug"};
     int const argc = sizeof(argv) / sizeof(*argv);
 
@@ -82,6 +110,35 @@ TEST(execute_test, few_ubs_debug)
 
     std::string const expected_file
     {
+
+        "##CONFIG:\n"
+        "##{\n"
+        "##    \"config\": {\n"
+        "##        \"version\": 1,\n"
+        "##        \"input_prefix\": \"" + input_prefix.get_path().string() + "\",\n"
+        "##        \"count_filename\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + ".count\"\n"
+        "##        },\n"
+        "##        \"sketch_directory\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + "_sketches\"\n"
+        "##        },\n"
+        "##        \"output_filename\": {\n"
+        "##            \"value0\": \"" + layout_file.get_path().string() + "\"\n"
+        "##        },\n"
+        "##        \"tmax\": 64,\n"
+        "##        \"num_hash_functions\": 2,\n"
+        "##        \"false_positive_rate\": 0.05,\n"
+        "##        \"alpha\": 1.2,\n"
+        "##        \"max_rearrangement_ratio\": 0.5,\n"
+        "##        \"threads\": 1,\n"
+        "##        \"estimate_union\": false,\n"
+        "##        \"rearrange_user_bins\": false,\n"
+        "##        \"determine_best_tmax\": false,\n"
+        "##        \"force_all_binnings\": false,\n"
+        "##        \"output_statistics\": false\n"
+        "##    }\n"
+        "##}\n"
+        "##ENDCONFIG\n"
         "#HIGH_LEVEL_IBF max_bin_id:6\n"
         "#FILES\tBIN_INDICES\tNUMBER_OF_BINS\tEST_MAX_TB_SIZES\tSCORE\tCORR\tT_MAX\n"
         "seq7\t0\t6\t83\t278\t2.86\t64\n"
@@ -122,9 +179,9 @@ TEST(execute_test, few_ubs_with_aggregatation)
 
     char const * const argv[] = {"./chopper-layout",
                                  "--tmax", "64",
-                                 "--aggregate-by", "2", /* specification column */
+                                 "--aggregate-by-column", "2", /* specification column */
                                  "--input-prefix", input_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str()};
+                                 "--output-filename", layout_file.get_path().c_str()};
     int const argc = sizeof(argv) / sizeof(*argv);
 
     seqan3::argument_parser layout_parser{"chopper-layout", argc, argv, seqan3::update_notifications::off};
@@ -132,6 +189,35 @@ TEST(execute_test, few_ubs_with_aggregatation)
 
     std::string const expected_file
     {
+
+        "##CONFIG:\n"
+        "##{\n"
+        "##    \"config\": {\n"
+        "##        \"version\": 1,\n"
+        "##        \"input_prefix\": \"" + input_prefix.get_path().string() + "\",\n"
+        "##        \"count_filename\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + ".count\"\n"
+        "##        },\n"
+        "##        \"sketch_directory\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + "_sketches\"\n"
+        "##        },\n"
+        "##        \"output_filename\": {\n"
+        "##            \"value0\": \"" + layout_file.get_path().string() + "\"\n"
+        "##        },\n"
+        "##        \"tmax\": 64,\n"
+        "##        \"num_hash_functions\": 2,\n"
+        "##        \"false_positive_rate\": 0.05,\n"
+        "##        \"alpha\": 1.2,\n"
+        "##        \"max_rearrangement_ratio\": 0.5,\n"
+        "##        \"threads\": 1,\n"
+        "##        \"estimate_union\": false,\n"
+        "##        \"rearrange_user_bins\": false,\n"
+        "##        \"determine_best_tmax\": false,\n"
+        "##        \"force_all_binnings\": false,\n"
+        "##        \"output_statistics\": false\n"
+        "##    }\n"
+        "##}\n"
+        "##ENDCONFIG\n"
         "#HIGH_LEVEL_IBF max_bin_id:6\n"
         "#FILES\tBIN_INDICES\tNUMBER_OF_BINS\n"
         "seq7\t0\t6\n"
@@ -163,7 +249,7 @@ TEST(execute_test, many_ubs_debug)
     char const * const argv[] = {"./chopper-layout",
                                  "--tmax", "64",
                                  "--input-prefix", input_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str(),
+                                 "--output-filename", layout_file.get_path().c_str(),
                                  "--debug"};
     int const argc = sizeof(argv) / sizeof(*argv);
 
@@ -172,6 +258,34 @@ TEST(execute_test, many_ubs_debug)
 
     std::string const expected_file
     {
+        "##CONFIG:\n"
+        "##{\n"
+        "##    \"config\": {\n"
+        "##        \"version\": 1,\n"
+        "##        \"input_prefix\": \"" + input_prefix.get_path().string() + "\",\n"
+        "##        \"count_filename\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + ".count\"\n"
+        "##        },\n"
+        "##        \"sketch_directory\": {\n"
+        "##            \"value0\": \"" + input_prefix.get_path().string() + "_sketches\"\n"
+        "##        },\n"
+        "##        \"output_filename\": {\n"
+        "##            \"value0\": \"" + layout_file.get_path().string() + "\"\n"
+        "##        },\n"
+        "##        \"tmax\": 64,\n"
+        "##        \"num_hash_functions\": 2,\n"
+        "##        \"false_positive_rate\": 0.05,\n"
+        "##        \"alpha\": 1.2,\n"
+        "##        \"max_rearrangement_ratio\": 0.5,\n"
+        "##        \"threads\": 1,\n"
+        "##        \"estimate_union\": false,\n"
+        "##        \"rearrange_user_bins\": false,\n"
+        "##        \"determine_best_tmax\": false,\n"
+        "##        \"force_all_binnings\": false,\n"
+        "##        \"output_statistics\": false\n"
+        "##    }\n"
+        "##}\n"
+        "##ENDCONFIG\n"
         "#HIGH_LEVEL_IBF max_bin_id:0\n"
         "#MERGED_BIN_0 max_bin_id:14\n"
         "#MERGED_BIN_1 max_bin_id:14\n"

--- a/test/api/layout/execute_with_estimation_test.cpp
+++ b/test/api/layout/execute_with_estimation_test.cpp
@@ -29,7 +29,7 @@ TEST(execute_estimation_test, few_ubs)
                                  "--tmax", "4",
                                  "--determine-best-tmax",
                                  "--input-prefix", input_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str()};
+                                 "--output-filename", layout_file.get_path().c_str()};
     int const argc = sizeof(argv) / sizeof(*argv);
 
     seqan3::argument_parser layout_parser{"chopper-layout", argc, argv, seqan3::update_notifications::off};
@@ -61,7 +61,7 @@ TEST(execute_estimation_test, many_ubs)
                                  "--tmax", "1024",
                                  "--determine-best-tmax",
                                  "--input-prefix", input_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str()};
+                                 "--output-filename", layout_file.get_path().c_str()};
     int const argc = sizeof(argv) / sizeof(*argv);
 
     seqan3::argument_parser layout_parser{"chopper-layout", argc, argv, seqan3::update_notifications::off};
@@ -90,7 +90,7 @@ TEST(execute_estimation_test, many_ubs_force_all)
                                  "--determine-best-tmax",
                                  "--force-all-binnings",
                                  "--input-prefix", input_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str()};
+                                 "--output-filename", layout_file.get_path().c_str()};
     int const argc = sizeof(argv) / sizeof(*argv);
 
     seqan3::argument_parser layout_parser{"chopper-layout", argc, argv, seqan3::update_notifications::off};

--- a/test/api/layout/execute_with_hll_test.cpp
+++ b/test/api/layout/execute_with_hll_test.cpp
@@ -52,9 +52,9 @@ TEST(execute_hll_test, few_ubs)
     }
 
     char const * const argv[] = {"./chopper-layout",
-                                 "--tmax", "4",
+                                 "--tmax", "64",
                                  "--input-prefix", io_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str()};
+                                 "--output-filename", layout_file.get_path().c_str()};
     int const argc = sizeof(argv) / sizeof(*argv);
 
     seqan3::argument_parser layout_parser{"chopper-layout", argc, argv, seqan3::update_notifications::off};
@@ -62,6 +62,34 @@ TEST(execute_hll_test, few_ubs)
 
     std::vector<std::string> const expected_components
     {
+        {"##CONFIG:"},
+        {"##{"},
+        {"##    \"config\": {"},
+        {"##        \"version\": 1,"},
+        {"##        \"input_prefix\": \"" + io_prefix.get_path().string() + "\","},
+        {"##        \"count_filename\": {"},
+        {"##            \"value0\": \"" + io_prefix.get_path().string() + ".count\""},
+        {"##        },"},
+        {"##        \"sketch_directory\": {"},
+        {"##            \"value0\": \"" + io_prefix.get_path().string() + "_sketches\""},
+        {"##        },"},
+        {"##        \"output_filename\": {"},
+        {"##            \"value0\": \"" + layout_file.get_path().string() + "\""},
+        {"##        },"},
+        {"##        \"tmax\": 64,"},
+        {"##        \"num_hash_functions\": 2,"},
+        {"##        \"false_positive_rate\": 0.05,"},
+        {"##        \"alpha\": 1.2,"},
+        {"##        \"max_rearrangement_ratio\": 0.5,"},
+        {"##        \"threads\": 1,"},
+        {"##        \"estimate_union\": false,"},
+        {"##        \"rearrange_user_bins\": false,"},
+        {"##        \"determine_best_tmax\": false,"},
+        {"##        \"force_all_binnings\": false,"},
+        {"##        \"output_statistics\": false"},
+        {"##    }"},
+        {"##}"},
+        {"##ENDCONFIG"},
         {"#HIGH_LEVEL_IBF max_bin_id:0"},
         {"#FILES\tBIN_INDICES\tNUMBER_OF_BINS"},
         {seq1_filename + "\t0\t48"},
@@ -70,6 +98,7 @@ TEST(execute_hll_test, few_ubs)
         {small_filename + "\t58\t6"},
         {small2_filename + "\t52\t6"}
     };
+
     std::string const actual_file{string_from_file(layout_file.get_path())};
 
     size_t line_count{};
@@ -219,7 +248,7 @@ TEST(execute_hll_test, many_ubs)
     char const * const argv[] = {"./chopper-layout",
                                  "--tmax", "4",
                                  "--input-prefix", io_prefix.get_path().c_str(),
-                                 "--output-file", layout_file.get_path().c_str()};
+                                 "--output-filename", layout_file.get_path().c_str()};
     int const argc = sizeof(argv) / sizeof(*argv);
 
     seqan3::argument_parser layout_parser{"chopper-layout", argc, argv, seqan3::update_notifications::off};
@@ -227,6 +256,34 @@ TEST(execute_hll_test, many_ubs)
 
     std::vector<std::string> const expected_components
     {
+        {"##CONFIG:"},
+        {"##{"},
+        {"##    \"config\": {"},
+        {"##        \"version\": 1,"},
+        {"##        \"input_prefix\": \"" + io_prefix.get_path().string() + "\","},
+        {"##        \"count_filename\": {"},
+        {"##            \"value0\": \"" + io_prefix.get_path().string() + ".count\""},
+        {"##        },"},
+        {"##        \"sketch_directory\": {"},
+        {"##            \"value0\": \"" + io_prefix.get_path().string() + "_sketches\""},
+        {"##        },"},
+        {"##        \"output_filename\": {"},
+        {"##            \"value0\": \"" + layout_file.get_path().string() + "\""},
+        {"##        },"},
+        {"##        \"tmax\": 64,"},
+        {"##        \"num_hash_functions\": 2,"},
+        {"##        \"false_positive_rate\": 0.05,"},
+        {"##        \"alpha\": 1.2,"},
+        {"##        \"max_rearrangement_ratio\": 0.5,"},
+        {"##        \"threads\": 1,"},
+        {"##        \"estimate_union\": false,"},
+        {"##        \"rearrange_user_bins\": false,"},
+        {"##        \"determine_best_tmax\": false,"},
+        {"##        \"force_all_binnings\": false,"},
+        {"##        \"output_statistics\": false"},
+        {"##    }"},
+        {"##}"},
+        {"##ENDCONFIG"},
         {"#HIGH_LEVEL_IBF max_bin_id:10"},
         {"#MERGED_BIN_10 max_bin_id:0"},
         {"#MERGED_BIN_11 max_bin_id:0"},

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -18,7 +18,7 @@ TEST(hibf_statistics, only_merged_on_top_level)
 
     chopper::layout::configuration config; // default config
     chopper::layout::data_store data;
-    data.compute_fp_correction(config.fp_rate, config.num_hash_functions, lower_level_split_bin_span);
+    data.compute_fp_correction(config.false_positive_rate, config.num_hash_functions, lower_level_split_bin_span);
 
     chopper::layout::hibf_statistics stats(config, data.fp_correction);
 

--- a/test/api/layout/hierarchical_binning_test.cpp
+++ b/test/api/layout/hierarchical_binning_test.cpp
@@ -14,14 +14,14 @@
 TEST(hierarchical_binning_test, filenames_and_kmer_counts_size_differs)
 {
     chopper::layout::configuration config;
-    config.t_max = 4;
+    config.tmax = 4;
 
     std::stringstream output_buffer;
     std::stringstream header_buffer;
     chopper::layout::data_store data;
     data.output_buffer = &output_buffer;
     data.header_buffer = &header_buffer;
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 
@@ -34,7 +34,7 @@ TEST(hierarchical_binning_test, filenames_and_kmer_counts_size_differs)
 TEST(hierarchical_binning_test, small_example)
 {
     chopper::layout::configuration config;
-    config.t_max = 4;
+    config.tmax = 4;
 
     std::stringstream output_buffer;
     std::stringstream header_buffer;
@@ -43,7 +43,7 @@ TEST(hierarchical_binning_test, small_example)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3", "seq4", "seq5", "seq6",  "seq7"};
     data.kmer_counts = {500, 1000, 500, 500, 500, 500, 500, 500};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
     chopper::layout::hierarchical_binning algo{data, config};
@@ -70,7 +70,7 @@ TEST(hierarchical_binning_test, small_example)
 TEST(hierarchical_binning_test, another_example)
 {
     chopper::layout::configuration config;
-    config.t_max = 5;
+    config.tmax = 5;
 
     std::stringstream output_buffer;
     std::stringstream header_buffer;
@@ -79,7 +79,7 @@ TEST(hierarchical_binning_test, another_example)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3", "seq4", "seq5", "seq6",  "seq7"};
     data.kmer_counts = {50, 1000, 1000, 50, 5, 10, 10, 5};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 
@@ -107,7 +107,7 @@ TEST(hierarchical_binning_test, another_example)
 TEST(hierarchical_binning_test, high_level_max_bin_id_is_0)
 {
     chopper::layout::configuration config;
-    config.t_max = 4;
+    config.tmax = 4;
 
     std::stringstream output_buffer;
     std::stringstream header_buffer;
@@ -116,7 +116,7 @@ TEST(hierarchical_binning_test, high_level_max_bin_id_is_0)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3"};
     data.kmer_counts = {500, 500, 500, 500};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 
@@ -139,7 +139,7 @@ TEST(hierarchical_binning_test, knuts_example)
 {
     chopper::layout::configuration config;
     config.alpha = 1;
-    config.t_max = 5;
+    config.tmax = 5;
 
     std::stringstream output_buffer;
     std::stringstream header_buffer;
@@ -148,7 +148,7 @@ TEST(hierarchical_binning_test, knuts_example)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3", "seq4"};
     data.kmer_counts = {60, 600, 1000, 800, 800};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 
@@ -172,7 +172,7 @@ TEST(hierarchical_binning_test, knuts_example)
 TEST(hierarchical_binning_test, four_level_hibf)
 {
     chopper::layout::configuration config;
-    config.t_max = 2;
+    config.tmax = 2;
     // config.debug = true;
 
     std::stringstream output_buffer;
@@ -182,7 +182,7 @@ TEST(hierarchical_binning_test, four_level_hibf)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3", "seq4", "seq5"};
     data.kmer_counts = {11090, 5080, 3040, 1020, 510, 500};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 
@@ -211,7 +211,7 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin)
 {
     chopper::layout::configuration config;
     config.alpha = 1;
-    config.t_max = 2;
+    config.tmax = 2;
 
     std::stringstream output_buffer;
     std::stringstream header_buffer;
@@ -220,7 +220,7 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3"};
     data.kmer_counts = {500, 500, 500, 500};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 
@@ -245,7 +245,7 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin_with_debug)
 {
     chopper::layout::configuration config;
     config.alpha = 1;
-    config.t_max = 2;
+    config.tmax = 2;
     config.debug = true;
 
     std::stringstream output_buffer;
@@ -255,7 +255,7 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin_with_debug)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3"};
     data.kmer_counts = {500, 500, 500, 500};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 
@@ -280,7 +280,7 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin_and_leads_to_recursive_call)
 {
     chopper::layout::configuration config;
     config.alpha = 1;
-    config.t_max = 2;
+    config.tmax = 2;
 
     std::stringstream output_buffer;
     std::stringstream header_buffer;
@@ -289,7 +289,7 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin_and_leads_to_recursive_call)
     data.header_buffer = &header_buffer;
     data.filenames = {"seq0", "seq1", "seq2", "seq3", "seq4", "seq5", "seq6", "seq7"};
     data.kmer_counts = {500, 500, 500, 500, 500, 500, 500, 500};
-    data.compute_fp_correction(0.05, 2, config.t_max);
+    data.compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hibf_statistics global_stats_dummy{};
     data.stats = &global_stats_dummy.top_level_ibf;
 

--- a/test/cli/cli_chopper_basic_test.cpp
+++ b/test/cli/cli_chopper_basic_test.cpp
@@ -106,7 +106,7 @@ TEST_F(cli_test, chopper_layout_cmd_error_no_extra_information)
     cli_test_result result = execute_app("chopper", "layout",
                                          "--tmax", "64",
                                          "--input-prefix", prefix.get_path(),
-                                         "--aggregate-by", "3");
+                                         "--aggregate-by-column", "3");
 
     std::string expected
     {
@@ -131,7 +131,7 @@ TEST_F(cli_test, chopper_layout_cmd_error_column_index_out_of_bounds)
     cli_test_result result = execute_app("chopper", "layout",
                                          "--tmax", "64",
                                          "--input-prefix", prefix.get_path(),
-                                         "--aggregate-by", "4");
+                                         "--aggregate-by-column", "4");
 
     std::string expected
     {

--- a/test/cli/cli_chopper_layout_statistics_test.cpp
+++ b/test/cli/cli_chopper_layout_statistics_test.cpp
@@ -19,7 +19,7 @@ TEST_F(cli_test, chopper_layout_statistics)
     cli_test_result layout_result = execute_app("chopper", "layout",
                                               "--tmax", "64",
                                               "--input-prefix", input_prefix.get_path().c_str(),
-                                              "--output-file", layout_file.get_path().c_str(),
+                                              "--output-filename", layout_file.get_path().c_str(),
                                               "--output-statistics");
 
     std::string expected_cout =
@@ -63,7 +63,7 @@ TEST_F(cli_test, chopper_layout_statistics_determine_best_bins)
     cli_test_result layout_result = execute_app("chopper", "layout",
                                               "--tmax", "128",
                                               "--input-prefix", input_prefixname.get_path().c_str(),
-                                              "--output-file", binning_filename.get_path().c_str(),
+                                              "--output-filename", binning_filename.get_path().c_str(),
                                               "--output-statistics",
                                               "--determine-best-tmax",
                                               "--force-all-binnings");

--- a/test/cli/cli_chopper_pipeline_test.cpp
+++ b/test/cli/cli_chopper_pipeline_test.cpp
@@ -75,7 +75,7 @@ TEST_F(cli_test, chopper_pipeline)
     cli_test_result layout_result = execute_app("chopper", "layout",
                                                 "--tmax", "64",
                                                 "--input-prefix", sketch_prefix.get_path().c_str(),
-                                                "--output-file", binning_filename.get_path().c_str());
+                                                "--output-filename", binning_filename.get_path().c_str());
 
     EXPECT_EQ(layout_result.exit_code, 0);
     EXPECT_EQ(layout_result.out, std::string{});
@@ -83,6 +83,34 @@ TEST_F(cli_test, chopper_pipeline)
 
     std::string expected_file
     {
+        "##CONFIG:\n"
+        "##{\n"
+        "##    \"config\": {\n"
+        "##        \"version\": 1,\n"
+        "##        \"input_prefix\": \"" + sketch_prefix.get_path().string() + "\",\n"
+        "##        \"count_filename\": {\n"
+        "##            \"value0\": \"" + sketch_prefix.get_path().string() + ".count\"\n"
+        "##        },\n"
+        "##        \"sketch_directory\": {\n"
+        "##            \"value0\": \"" + sketch_prefix.get_path().string() + "_sketches\"\n"
+        "##        },\n"
+        "##        \"output_filename\": {\n"
+        "##            \"value0\": \"" + binning_filename.get_path().string() + "\"\n"
+        "##        },\n"
+        "##        \"tmax\": 64,\n"
+        "##        \"num_hash_functions\": 2,\n"
+        "##        \"false_positive_rate\": 0.05,\n"
+        "##        \"alpha\": 1.2,\n"
+        "##        \"max_rearrangement_ratio\": 0.5,\n"
+        "##        \"threads\": 1,\n"
+        "##        \"estimate_union\": false,\n"
+        "##        \"rearrange_user_bins\": false,\n"
+        "##        \"determine_best_tmax\": false,\n"
+        "##        \"force_all_binnings\": false,\n"
+        "##        \"output_statistics\": false\n"
+        "##    }\n"
+        "##}\n"
+        "##ENDCONFIG\n"
         "#HIGH_LEVEL_IBF max_bin_id:22\n"
         "#FILES\tBIN_INDICES\tNUMBER_OF_BINS\n" +
         seq_filename + "\t0\t22\n" +
@@ -165,7 +193,7 @@ TEST_F(cli_test, chopper_pipeline2)
                                                 "--threads", "2",
                                                 "--rearrange-user-bins",
                                                 "--input-prefix", sketch_prefix.get_path().c_str(),
-                                                "--output-file", binning_filename.get_path().c_str());
+                                                "--output-filename", binning_filename.get_path().c_str());
 
     EXPECT_EQ(layout_result.exit_code, 0);
     EXPECT_EQ(layout_result.out, std::string{});
@@ -173,6 +201,34 @@ TEST_F(cli_test, chopper_pipeline2)
 
     std::string expected_file
     {
+        "##CONFIG:\n"
+        "##{\n"
+        "##    \"config\": {\n"
+        "##        \"version\": 1,\n"
+        "##        \"input_prefix\": \"" + sketch_prefix.get_path().string() + "\",\n"
+        "##        \"count_filename\": {\n"
+        "##            \"value0\": \"" + sketch_prefix.get_path().string() + ".count\"\n"
+        "##        },\n"
+        "##        \"sketch_directory\": {\n"
+        "##            \"value0\": \"" + sketch_prefix.get_path().string() + "_sketches\"\n"
+        "##        },\n"
+        "##        \"output_filename\": {\n"
+        "##            \"value0\": \"" + binning_filename.get_path().string() + "\"\n"
+        "##        },\n"
+        "##        \"tmax\": 64,\n"
+        "##        \"num_hash_functions\": 2,\n"
+        "##        \"false_positive_rate\": 0.05,\n"
+        "##        \"alpha\": 1.2,\n"
+        "##        \"max_rearrangement_ratio\": 0.5,\n"
+        "##        \"threads\": 2,\n"
+        "##        \"estimate_union\": true,\n"
+        "##        \"rearrange_user_bins\": true,\n"
+        "##        \"determine_best_tmax\": false,\n"
+        "##        \"force_all_binnings\": false,\n"
+        "##        \"output_statistics\": false\n"
+        "##    }\n"
+        "##}\n"
+        "##ENDCONFIG\n"
         "#HIGH_LEVEL_IBF max_bin_id:56\n"
         "#FILES\tBIN_INDICES\tNUMBER_OF_BINS\n" +
         seq3_filename + "\t0\t14\n" +


### PR DESCRIPTION
Alternative to #82 by using cereal.

I don't know if the escaping of `\"` looks right in files. I'll check.

an example now looks like this (I only included two parameters for aesthetic reasons)

```
##CONFIG:
##{
##    "config": {
##        "data_file.string()": "test/data/filenames_and_counts.tsv",
##        "t_max": 64
##    }
##ENDCONFIG
#HIGH_LEVEL_IBF max_bin_id:0
#FILES  BIN_INDICES     NUMBER_OF_BINS
file1   0       3
file2   3       11
file3   14      50
```