### PR TITLE
[FIX] Always round up kmer count when splitting bins.

### DIFF
--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -351,7 +351,7 @@ private:
             }
             else // split bin
             {
-                size_t const kmer_count_per_bin = kmer_count / number_of_bins; // round down
+                size_t const kmer_count_per_bin = (kmer_count + number_of_bins - 1) / number_of_bins; // round up
 
                 // add split bin to ibf statistics
                 if (data->stats)
@@ -414,7 +414,7 @@ private:
             // that the bin was split (even if only into 1 bin).
             size_t const kmer_count = data->kmer_counts[0];
             size_t const number_of_tbs = trace_i + 1;
-            size_t const average_bin_size = kmer_count / number_of_tbs;
+            size_t const average_bin_size = (kmer_count + number_of_tbs - 1) / number_of_tbs; // round up
 
             // add split bin to ibf statistics
             if (data->stats)

--- a/test/api/layout/execute_layout_test.cpp
+++ b/test/api/layout/execute_layout_test.cpp
@@ -141,14 +141,14 @@ TEST(execute_test, few_ubs_debug)
         "##ENDCONFIG\n"
         "#HIGH_LEVEL_IBF max_bin_id:6\n"
         "#FILES\tBIN_INDICES\tNUMBER_OF_BINS\tEST_MAX_TB_SIZES\tSCORE\tCORR\tT_MAX\n"
-        "seq7\t0\t6\t83\t278\t2.86\t64\n"
+        "seq7\t0\t6\t84\t278\t2.86\t64\n"
         "seq6\t6\t4\t125\t278\t2.23\t64\n"
         "seq5\t10\t4\t125\t278\t2.23\t64\n"
         "seq4\t14\t4\t125\t278\t2.23\t64\n"
         "seq3\t18\t4\t125\t278\t2.23\t64\n"
         "seq2\t22\t4\t125\t278\t2.23\t64\n"
         "seq0\t26\t4\t125\t278\t2.23\t64\n"
-        "seq1\t30\t34\t29\t278\t9.44\t64\n"
+        "seq1\t30\t34\t30\t278\t9.44\t64\n"
     };
     std::string const actual_file{string_from_file(layout_file.get_path())};
 


### PR DESCRIPTION
I think this doesn't affect data with large kmer counts but still we should be consistent.
In `simple_binning.hpp` we always round up but in `hierarchical_binning.hpp` we round down.
Since we use the kmer counts to estimate the IBF size given a FPR rate we should round up, since that way we make sure to keep the desired FPR.