### PR TITLE
[MISC] Move computation of estimated query cost into hibf_statistics.

### DIFF
--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -283,10 +283,12 @@ private:
 
         for (bin const & current_bin : curr_level.bins)
         {
-            size_t const corrected_cardinality = std::ceil(current_bin.cardinality *
+            size_t const cardinality_per_split_bin = (current_bin.cardinality + current_bin.num_spanning_tbs - 1) /
+                                                     current_bin.num_spanning_tbs; // round up
+            size_t const corrected_cardinality = std::ceil(cardinality_per_split_bin *
                                                            (*fp_correction)[current_bin.num_spanning_tbs]);
             max_cardinality = std::max(max_cardinality, corrected_cardinality);
-            max_cardinality_no_corr = std::max(max_cardinality_no_corr, current_bin.cardinality);
+            max_cardinality_no_corr = std::max(max_cardinality_no_corr, cardinality_per_split_bin);
 
             num_tbs += current_bin.num_spanning_tbs;
             num_ubs += current_bin.num_contained_ubs;
@@ -296,7 +298,7 @@ private:
                 num_split_tbs += current_bin.num_spanning_tbs;
                 num_split_ubs += 1;
                 split_tb_corr_kmers += corrected_cardinality * current_bin.num_spanning_tbs;
-                split_tb_kmers += current_bin.cardinality * current_bin.num_spanning_tbs;
+                split_tb_kmers += cardinality_per_split_bin * current_bin.num_spanning_tbs;
                 max_split_tb_span = std::max(max_split_tb_span, current_bin.num_spanning_tbs);
                 total_query_cost += current_bin.estimated_query_cost;
             }

--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -65,7 +65,6 @@ public:
         size_t const cardinality; //!< The size/weight of the bin (either a kmer count or hll sketch estimation).
         size_t const num_contained_ubs; //!< [MERGED] How many UBs are merged within this TB.
         size_t const num_spanning_tbs; //!< [SPLIT] How many TBs are used for this sindle UB.
-        double const estimated_query_cost; //!< [SPLIT] Whats the estimated query cost of querying all kmers of this UB.
 
         level child_level; //!< [MERGED] The lower level ibf statistics.
 
@@ -79,13 +78,11 @@ public:
         bin(bin_kind const kind_,
             size_t const card,
             size_t const contained_ubs,
-            size_t const spanning_tbs,
-            double const cost = 0.0) :
+            size_t const spanning_tbs) :
             kind{kind_},
             cardinality{card},
             num_contained_ubs{contained_ubs},
-            num_spanning_tbs{spanning_tbs},
-            estimated_query_cost{cost}
+            num_spanning_tbs{spanning_tbs}
         {
             assert((kind == bin_kind::split  && num_contained_ubs == 1u) ||
                    (kind == bin_kind::merged && num_spanning_tbs  == 1u));
@@ -300,7 +297,7 @@ private:
                 split_tb_corr_kmers += corrected_cardinality * current_bin.num_spanning_tbs;
                 split_tb_kmers += cardinality_per_split_bin * current_bin.num_spanning_tbs;
                 max_split_tb_span = std::max(max_split_tb_span, current_bin.num_spanning_tbs);
-                total_query_cost += current_bin.estimated_query_cost;
+                total_query_cost += curr_level.current_query_cost * current_bin.cardinality;
             }
             else
             {

--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -179,7 +179,7 @@ public:
     size_t total_hibf_size_in_byte()
     {
         if (summaries.empty())
-            gather_statistics(top_level_ibf, 0);
+            finalize();
 
         size_t total_size{};
 

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -357,7 +357,7 @@ private:
                 if (data->stats)
                 {
                     data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
-                                                kmer_count_per_bin,
+                                                kmer_count,
                                                 1ul,
                                                 number_of_bins,
                                                 data->stats->current_query_cost * kmer_count);
@@ -420,7 +420,7 @@ private:
             if (data->stats)
             {
                 data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
-                                               average_bin_size,
+                                               kmer_count,
                                                1ul,
                                                number_of_tbs,
                                                data->stats->current_query_cost * kmer_count);

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -359,8 +359,7 @@ private:
                     data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
                                                 kmer_count,
                                                 1ul,
-                                                number_of_bins,
-                                                data->stats->current_query_cost * kmer_count);
+                                                number_of_bins);
                 }
 
                 if (!config.debug)
@@ -422,8 +421,7 @@ private:
                 data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
                                                kmer_count,
                                                1ul,
-                                               number_of_tbs,
-                                               data->stats->current_query_cost * kmer_count);
+                                               number_of_tbs);
             }
 
             if (!config.debug)

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -5,7 +5,6 @@
 
 #include <chopper/prefixes.hpp>
 #include <chopper/helper.hpp>
-#include <chopper/layout/ibf_query_cost.hpp>
 #include <chopper/layout/configuration.hpp>
 #include <chopper/layout/print_result_line.hpp>
 #include <chopper/layout/arrange_user_bins.hpp>
@@ -299,11 +298,6 @@ private:
                 *data->output_buffer << prefix::header << "FILES\tBIN_INDICES\tNUMBER_OF_BINS" << std::endl;
         }
 
-        // The cost for querying `num_technical_bins` bins.
-        double const interpolated_cost{ibf_query_cost::interpolated(num_technical_bins, config.false_positive_rate)};
-        if (data->stats)
-            data->stats->current_query_cost += interpolated_cost;
-
         // backtracking starts at the bottom right corner:
         size_t trace_i = num_technical_bins - 1;
         size_t trace_j = num_user_bins - 1;
@@ -480,7 +474,6 @@ private:
             hibf_statistics::bin & bin_stats = data->stats->bins.emplace_back(hibf_statistics::bin_kind::merged,
                                                 cardinality, num_contained_ubs, 1ul);
             libf_data.stats = &bin_stats.child_level;
-            libf_data.stats->current_query_cost = data->stats->current_query_cost;
         }
 
         // now do the binning for the low-level IBF:

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -231,8 +231,7 @@ public:
                 data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
                                                kmer_count,
                                                1ul,
-                                               number_of_bins,
-                                               data->stats->current_query_cost * kmer_count);
+                                               number_of_bins);
             }
 
             if (!debug)
@@ -261,8 +260,7 @@ public:
             data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
                                            kmer_count,
                                            1ul,
-                                           trace_i,
-                                           data->stats->current_query_cost * kmer_count);
+                                           trace_i);
         }
 
         if (kmer_count_per_bin > max_size)

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -9,7 +9,6 @@
 
 #include <chopper/helper.hpp>
 #include <chopper/layout/data_store.hpp>
-#include <chopper/layout/ibf_query_cost.hpp>
 #include <chopper/layout/previous_level.hpp>
 #include <chopper/layout/print_matrix.hpp>
 #include <chopper/layout/print_result_line.hpp>
@@ -206,9 +205,6 @@ public:
         // print_matrix(trace, num_technical_bins, num_user_bins, std::numeric_limits<size_t>::max());
 
         // backtracking
-        if (data->stats)
-            data->stats->current_query_cost += ibf_query_cost::interpolated(num_technical_bins, data->false_positive_rate);
-
         size_t trace_i = num_technical_bins - 1;
         size_t trace_j = num_user_bins - 1;
 

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -229,7 +229,7 @@ public:
             if (data->stats)
             {
                 data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
-                                               kmer_count_per_bin,
+                                               kmer_count,
                                                1ul,
                                                number_of_bins,
                                                data->stats->current_query_cost * kmer_count);
@@ -259,7 +259,7 @@ public:
         if (data->stats)
         {
             data->stats->bins.emplace_back(hibf_statistics::bin_kind::split,
-                                           kmer_count_per_bin,
+                                           kmer_count,
                                            1ul,
                                            trace_i,
                                            data->stats->current_query_cost * kmer_count);

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -16,8 +16,8 @@ TEST(hibf_statistics, only_merged_on_top_level)
     size_t const top_level_num_contained_user_bins = 2u;
     size_t const lower_level_split_bin_span = 1u;
 
-    chopper::layout::configuration config; // default config
-    chopper::layout::data_store data;
+    chopper::layout::configuration config{}; // default config
+    chopper::layout::data_store data{};
     data.compute_fp_correction(config.false_positive_rate, config.num_hash_functions, lower_level_split_bin_span);
     std::vector<size_t> kmer_counts{50, 50};
 
@@ -53,9 +53,9 @@ TEST(hibf_statistics, only_merged_on_top_level)
     std::string expected_cout =
 R"expected_cout(#T_Max:64
 #C_{T_Max}:1.00
-#relative expected HIBF query time cost (l):0.00
+#relative expected HIBF query time cost (l):16.00
 #relative HIBF memory usage (m):1.00
-#l*m:0.00
+#l*m:16.00
 level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
 0	1	395 Bytes	395 Bytes	4	4	0.00	-	-	-	-
 1	4	790 Bytes	790 Bytes	8	2	100.00	1	1.00	1.00	1.00


### PR DESCRIPTION
While working on adding merged bin similarities in the query cost estimation, I first refactored the code s.t. the query cost estimation computation is within a single function and not splattered across the code.

Best reviewed commit by commit to understand the individual steps. 
But it is not too important because it is just a refactoring. None of the tests had to be changed/adapted except one: `hibf_statistics_test.cpp` which tests the `hibf_statistics` class independently from the DP algorithm. Since I compute the query costs within `hibf_statistics` now, they also had to be added in this test.