### PR TITLE
[FEATURE] Improve query cost estimation (l_tmax) with hll sketches

### DIFF
--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -298,6 +298,9 @@ private:
                 *data->output_buffer << prefix::header << "FILES\tBIN_INDICES\tNUMBER_OF_BINS" << std::endl;
         }
 
+        if (data->stats)
+            data->stats->filenames = data->filenames;
+
         // backtracking starts at the bottom right corner:
         size_t trace_i = num_technical_bins - 1;
         size_t trace_j = num_user_bins - 1;

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -160,6 +160,9 @@ public:
         assert(data->output_buffer != nullptr);
         assert(data->header_buffer != nullptr);
 
+        if (data->stats)
+            data->stats->filenames = data->filenames;
+
         std::vector<std::vector<size_t>> matrix(num_technical_bins); // rows
         for (auto & v : matrix)
             v.resize(num_user_bins, std::numeric_limits<size_t>::max()); // columns

--- a/test/api/layout/CMakeLists.txt
+++ b/test/api/layout/CMakeLists.txt
@@ -10,7 +10,13 @@ add_api_test (hierarchical_binning_test.cpp)
 add_api_test (ibf_query_cost_test.cpp)
 add_api_test (aggregate_by_test.cpp)
 add_api_test (execute_layout_test.cpp)
+
 add_api_test (execute_with_estimation_test.cpp)
+target_use_datasources (execute_with_estimation_test FILES seq1.fa)
+target_use_datasources (execute_with_estimation_test FILES seq2.fa)
+target_use_datasources (execute_with_estimation_test FILES seq3.fa)
+target_use_datasources (execute_with_estimation_test FILES small.fa)
+
 add_api_test (execute_with_hll_test.cpp)
 add_api_test (fp_correction_test.cpp)
 add_api_test (hibf_statistics_test.cpp)

--- a/test/api/layout/execute_with_estimation_test.cpp
+++ b/test/api/layout/execute_with_estimation_test.cpp
@@ -224,8 +224,8 @@ R"expected_cout(## ### Parameters ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 #tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
-64	1.00	1.69	1.00	1.69	116KiB
-128	0.96	1.50	1.15	1.73	134KiB
+64	1.00	2.23	1.00	2.23	116KiB
+128	0.96	1.57	1.15	1.81	134KiB
 256	1.20	1.39	1.19	1.66	138KiB
 #Best t_max (regarding expected query runtime):256
 )expected_cout");

--- a/test/api/sketch/user_bin_sequence_test.cpp
+++ b/test/api/sketch/user_bin_sequence_test.cpp
@@ -114,6 +114,17 @@ TEST_F(user_bin_sequence_test, read_hll_files_empty_dir)
 #endif
 }
 
+TEST_F(user_bin_sequence_test, read_hll_files_file_is_missing)
+{
+    seqan3::test::tmp_filename const tmp_file{"other.hll"};
+    {
+        std::ofstream os{tmp_file.get_path()};
+        os << "Doesn't matter I just need to exist\n";
+    }
+
+    EXPECT_THROW(this->read_hll_files(tmp_file.get_path().parent_path()), std::runtime_error);
+}
+
 TEST_F(user_bin_sequence_test, read_hll_files_faulty_file)
 {
     seqan3::test::tmp_filename const tmp_file{"small.hll"};


### PR DESCRIPTION
Depends on #98 To see the difference in the test when introducing similarities.

data: RefSeq CompleteGenomes Archea/Bacteria

Query cost **before** this change:
```
tmax  c_tmax  l_tmax  m_tmax (l*m)_tmax  size
----------------------------------------------
64      1.00    2.91    1.00    2.91    292GiB
128     1.20    2.75    0.81    2.22    235GiB
192     1.28    2.51    0.69    1.74    202GiB
256     1.36    2.59    0.68    1.75    197GiB
512     2.01    3.34    0.70    2.33    204GiB
1024    2.64    3.84    0.77    2.97    226GiB
2048    3.37    4.47    0.88    3.92    256GiB
4096    5.98    6.96    0.95    6.62    277GiB
8192    9.92    10.65   0.83    8.88    243GiB
```

Query cost **after** this change:
```
tmax  c_tmax  l_tmax  m_tmax (l*m)_tmax  size
-------------------------------------------------
64      1.00    4.17    1.00    4.17    292GiB
128     1.20    4.11    0.81    3.31    235GiB
192     1.28    3.10    0.69    2.15    202GiB
256     1.36    3.16    0.68    2.14    197GiB
512     2.01    4.25    0.70    2.97    204GiB
1024    2.64    6.02    0.77    4.67    226GiB
2048    3.37    8.96    0.88    7.85    256GiB
4096    5.98    15.60   0.95    14.83   277GiB
8192    9.92    18.12   0.83    15.11   243GiB
```

Real time measurements of query costs:
```
TMAX  SIZE  m_tmax   TIME    l_tmax
----------------------------------
64     86G   1.00   144.67    1.00
128    68G   0.79   126.91    0.87
192    55G   0.63    84.77    0.58
256    63G   0.73    83.15    0.57
512    59G   0.68    84.69    0.58
1024   70G   0.81   104.31    0.72
2048   77G   0.89   139.15    0.96
4096   83G   0.96   241.36    1.66
8192   65G   0.75   338.86    2.34
```