### PR TITLE
[TEST] Add determine best tmax test with rearrangement.

### DIFF
--- a/include/chopper/count/output.hpp
+++ b/include/chopper/count/output.hpp
@@ -31,11 +31,11 @@ inline void write_sketch_file(std::pair<std::string, std::vector<std::string>> c
     auto & [key, filepaths] = cluster;
     // For more than one file in the cluster, Felix doesn't know how to name the file
     // and what exactly is supposed to happen.
-    if (filepaths.size() > 1)
+    if (filepaths.size() != 1)
         throw std::runtime_error("This mode is not implemented yet for multiple files grouped together.");
 
     // For one file in the cluster, the file stem is used with the .hll ending
-    std::filesystem::path path = config.sketch_directory / std::filesystem::path(key).stem();
+    std::filesystem::path path = config.sketch_directory / std::filesystem::path(filepaths[0]).stem();
     path += ".hll";
     std::ofstream hll_fout(path, std::ios::binary);
     sketch.dump(hll_fout);


### PR DESCRIPTION
The change in `include/chopper/count/output.hpp` was necessary because I used the same files over and over again in the test and usually they get clustered together because the filename is used as a key in the filename_cluster map. Therefore I added dummy information in the second column. But then the hll sketch files were named after the dummy key instead of the filename. This small change fixes that.

But it only works correctly if there is exactly one file per key. The if clause catches this so it's safe for now.