### PR TITLE
[FEATURE] Do not compute the full union estiamtion matrix.

### DIFF
--- a/include/chopper/layout/arrange_user_bins.hpp
+++ b/include/chopper/layout/arrange_user_bins.hpp
@@ -2,7 +2,6 @@
 
 #include <chopper/layout/configuration.hpp>
 #include <chopper/layout/data_store.hpp>
-#include <chopper/sketch/user_bin_sequence.hpp>
 
 namespace chopper::layout
 {
@@ -12,16 +11,16 @@ inline void arrange_user_bins(data_store & data, configuration const & config)
 {
     if (!data.user_bins_arranged)
     {
-        chopper::sketch::user_bin_sequence bin_sequence{data.filenames, data.kmer_counts};
-        bin_sequence.sort_by_cardinalities();
+        data.sketch_toolbox = sketch::user_bin_sequence{data.filenames, data.kmer_counts};
+        data.sketch_toolbox.sort_by_cardinalities();
 
         if (config.estimate_union)
         {
-            bin_sequence.read_hll_files(config.sketch_directory);
+            data.sketch_toolbox.read_hll_files(config.sketch_directory);
             if (config.rearrange_user_bins)
-                bin_sequence.rearrange_bins(config.max_rearrangement_ratio, config.threads);
+                data.sketch_toolbox.rearrange_bins(config.max_rearrangement_ratio, config.threads);
 
-            bin_sequence.precompute_interval_union_estimations(data.union_estimates, config.threads);
+            data.sketch_toolbox.precompute_interval_union_estimations(data.union_estimates, config.threads);
         }
 
         data.user_bins_arranged = true;

--- a/include/chopper/layout/arrange_user_bins.hpp
+++ b/include/chopper/layout/arrange_user_bins.hpp
@@ -21,7 +21,7 @@ inline void arrange_user_bins(data_store & data, configuration const & config)
             if (config.rearrange_user_bins)
                 bin_sequence.rearrange_bins(config.max_rearrangement_ratio, config.threads);
 
-            bin_sequence.estimate_interval_unions(data.union_estimates, config.threads);
+            bin_sequence.precompute_interval_union_estimations(data.union_estimates, config.threads);
         }
 
         data.user_bins_arranged = true;

--- a/include/chopper/layout/arrange_user_bins.hpp
+++ b/include/chopper/layout/arrange_user_bins.hpp
@@ -19,8 +19,6 @@ inline void arrange_user_bins(data_store & data, configuration const & config)
             data.sketch_toolbox.read_hll_files(config.sketch_directory);
             if (config.rearrange_user_bins)
                 data.sketch_toolbox.rearrange_bins(config.max_rearrangement_ratio, config.threads);
-
-            data.sketch_toolbox.precompute_interval_union_estimations(data.union_estimates, config.threads);
         }
 
         data.user_bins_arranged = true;

--- a/include/chopper/layout/data_store.hpp
+++ b/include/chopper/layout/data_store.hpp
@@ -29,7 +29,7 @@ struct data_store
     double false_positive_rate{};
 
     //!\brief Matrix of estimates of merged bin cardinalites
-    std::vector<std::vector<uint64_t>> union_estimates{};
+    std::vector<uint64_t> union_estimates{};
     bool user_bins_arranged{false};
 
     //!\brief A reference to the output stream to cache the results to.

--- a/include/chopper/layout/data_store.hpp
+++ b/include/chopper/layout/data_store.hpp
@@ -8,6 +8,7 @@
 #include <chopper/layout/configuration.hpp>
 #include <chopper/layout/hibf_statistics.hpp>
 #include <chopper/layout/previous_level.hpp>
+#include <chopper/sketch/user_bin_sequence.hpp>
 
 namespace chopper::layout
 {
@@ -20,6 +21,9 @@ struct data_store
     std::vector<size_t> kmer_counts{};
     std::vector<std::vector<std::string>> extra_information{};
     std::vector<double> fp_correction{};
+
+    //!\brief Stores sketches if needed and provides utility functions for user bin rearrangement or union estimation.
+    sketch::user_bin_sequence sketch_toolbox;
 
     //!\brief The desired maximum false positive rate of the resulting index.
     double false_positive_rate{};

--- a/include/chopper/sketch/user_bin_sequence.hpp
+++ b/include/chopper/sketch/user_bin_sequence.hpp
@@ -53,10 +53,10 @@ protected:
     using distance_matrix = std::vector<entry>;
 
     //!\brief A pointer to the filenames of the user input sequences.
-    std::vector<std::string> * const filenames{nullptr};
+    std::vector<std::string> * filenames{nullptr};
 
     //!\brief A pointer to kmer counts associated with the above files used to layout user bin into technical bins.
-    std::vector<size_t> * const user_bin_kmer_counts{nullptr};
+    std::vector<size_t> * user_bin_kmer_counts{nullptr};
 
     //!\brief HyperLogLog sketches on the k-mer sets of the sequences from the files of filenames.
     std::vector<hyperloglog> sketches;

--- a/include/chopper/sketch/user_bin_sequence.hpp
+++ b/include/chopper/sketch/user_bin_sequence.hpp
@@ -149,7 +149,7 @@ public:
      * \param[in] num_threads the number of threads to use
      * \param[out] estimates output table
      */
-    void estimate_interval_unions(std::vector<std::vector<uint64_t>> & estimates, size_t const num_threads) const
+    void precompute_interval_union_estimations(std::vector<std::vector<uint64_t>> & estimates, size_t const num_threads) const
     {
         assert(user_bin_kmer_counts != nullptr);
         assert(filenames != nullptr);

--- a/include/chopper/sketch/user_bin_sequence.hpp
+++ b/include/chopper/sketch/user_bin_sequence.hpp
@@ -142,70 +142,65 @@ public:
         }
     }
 
-    /*!\brief For all intervals of filenames: estimate the cardinality of the union
-     * of k-mer sets of all sequences in the files of the interval.
-     * estimates[i][j] will be the union cardinality estimate of the interval j, ..., i.
-     * This unintuitive convention is chosen for cache efficiency in the hierarchical binning.
-     * \param[in] num_threads the number of threads to use
-     * \param[out] estimates output table
-     */
-    void precompute_interval_union_estimations(std::vector<std::vector<uint64_t>> & estimates, size_t const num_threads) const
-    {
-        assert(user_bin_kmer_counts != nullptr);
-        assert(filenames != nullptr);
-
-        if (filenames->size() > sketches.size())
-            throw std::runtime_error{"You need to compute or load sketches before you can estimate intervals."};
-
-        estimates.clear();
-        size_t const n = filenames->size();
-        estimates.resize(n);
-
-        size_t const chunk_size = std::floor(std::sqrt(n));
-
-        #pragma omp parallel num_threads(num_threads)
-        {
-            // initialize estimates
-            #pragma omp for
-            for (size_t i = 0; i < n; ++i)
-            {
-                estimates[i].resize(i + 1);
-            }
-
-            // fill estimates
-            #pragma omp for schedule(nonmonotonic: dynamic, chunk_size)
-            for (size_t i = 0; i < n; ++i)
-            {
-                hyperloglog temp_hll = sketches[i];
-                estimates[i][i] = (*user_bin_kmer_counts)[i];
-
-                for (size_t j = i + 1; j < n; ++j)
-                {
-                    estimates[j][i] = static_cast<uint64_t>(temp_hll.merge_and_estimate_SIMD(sketches[j]));
-                }
-            }
-        }
-    }
-
-    /*!\brief Estimate the cardinality of the union for a signle user bin j with all prior ones j' < j.
+    /*!\brief Estimate the cardinality of the union for a single user bin j with all prior ones j' < j.
      * \param[in] j The current user bin (column in the DP matrix)
      * \param[out] estimates output row
      *
      * estimates[j_prime] will be the union cardinality estimate of the interval {j_prime, ..., j}.
      */
-    void precompute_interval_union_estimations(std::vector<uint64_t> & estimates, int64_t const j) const
+    void precompute_union_estimates_for(std::vector<uint64_t> & estimates, int64_t const j) const
     {
         assert(user_bin_kmer_counts != nullptr);
-        assert(filenames->size() == sketches.size())
-        assert(estimates.capacity() > j);
-
-        estimates.clear();
+        assert(filenames->size() == user_bin_kmer_counts->size());
+        assert(filenames->size() == sketches.size());
+        assert(filenames->size() > static_cast<size_t>(j));
+        assert(estimates.size() == sketches.size()); // Resize happens in precompute_init_interval_union_estimations
 
         hyperloglog temp_hll = sketches[j];
         estimates[j] = (*user_bin_kmer_counts)[j];
 
         for (int64_t j_prime = j - 1; j_prime >= 0; --j_prime)
             estimates[j_prime] = static_cast<uint64_t>(temp_hll.merge_and_estimate_SIMD(sketches[j_prime]));
+    }
+
+    /*!\brief Estimate the cardinality of the union for each interval [0, j] for all user bins j.
+     * \param[out] estimates output row
+     *
+     * estimates[j] will be the union cardinality estimate of the interval {0, ..., j}.
+     */
+    void precompute_initial_union_estimates(std::vector<uint64_t> & estimates) const
+    {
+        assert(user_bin_kmer_counts != nullptr);
+        assert(filenames->size() == user_bin_kmer_counts->size());
+        assert(filenames->size() == sketches.size());
+        assert(filenames->size() > 0u);
+        estimates.resize(sketches.size());
+
+        hyperloglog temp_hll = sketches[0];
+        estimates[0] = (*user_bin_kmer_counts)[0];
+
+        for (size_t j = 1; j < sketches.size(); ++j)
+            estimates[j] = static_cast<uint64_t>(temp_hll.merge_and_estimate_SIMD(sketches[j]));
+    }
+
+    /*!\brief Estimate the cardinality of the union for a single interval.
+     * \param[in] start The start of the interval.
+     * \param[in] end   The end of the interval (end >= start);
+     */
+    uint64_t estimate_interval(size_t const start, size_t const end) const
+    {
+        assert(user_bin_kmer_counts != nullptr);
+        assert(filenames->size() == user_bin_kmer_counts->size());
+        assert(filenames->size() == sketches.size());
+        assert(start <= end);
+        assert(end < sketches.size());
+
+        hyperloglog temp_hll = sketches[start];
+
+        for (size_t i = start + 1; i <= end; ++i)
+            temp_hll.merge(sketches[i]);
+
+        return temp_hll.estimate();
     }
 
     /*!\brief Rearrange filenames, sketches and counts such that similar bins are close to each other

--- a/test/api/sketch/user_bin_sequence_test.cpp
+++ b/test/api/sketch/user_bin_sequence_test.cpp
@@ -41,10 +41,8 @@ TEST_F(user_bin_sequence_test, construction)
     EXPECT_TRUE(std::is_copy_constructible<chopper::sketch::user_bin_sequence>::value);
     EXPECT_TRUE(std::is_move_constructible<chopper::sketch::user_bin_sequence>::value);
     EXPECT_TRUE(std::is_destructible<chopper::sketch::user_bin_sequence>::value);
-
-    // class has a const pointer
-    EXPECT_FALSE(std::is_copy_assignable<chopper::sketch::user_bin_sequence>::value);
-    EXPECT_FALSE(std::is_move_assignable<chopper::sketch::user_bin_sequence>::value);
+    EXPECT_TRUE(std::is_copy_assignable<chopper::sketch::user_bin_sequence>::value);
+    EXPECT_TRUE(std::is_move_assignable<chopper::sketch::user_bin_sequence>::value);
 
     // construction from filenames and kmer_counts
     std::vector<std::string> filenames{"small.fa", "small.fa"};

--- a/test/api/sketch/user_bin_sequence_test.cpp
+++ b/test/api/sketch/user_bin_sequence_test.cpp
@@ -134,33 +134,25 @@ TEST_F(user_bin_sequence_test, read_hll_files_faulty_file)
     EXPECT_THROW(this->read_hll_files(tmp_file.get_path().parent_path()), std::runtime_error);
 }
 
-TEST_F(user_bin_sequence_test, precompute_interval_union_estimations_error_no_sketches)
+TEST_F(user_bin_sequence_test, precompute_union_estimates_for)
 {
-    std::vector<std::vector<uint64_t>> estimates{};
+    using vt = std::vector<uint64_t>;
 
-    EXPECT_THROW(this->precompute_interval_union_estimations(estimates, 1u), std::runtime_error);
-}
-
-TEST_F(user_bin_sequence_test, precompute_interval_union_estimations_one_thread)
-{
-    std::vector<std::vector<uint64_t>> expected{{{500},{670,600},{670,670,700},{670,670,670,800}}};
-
-    std::vector<std::vector<uint64_t>> estimates{};
     this->read_hll_files(data("")); // load hll files for test_filenames from data directory
-    this->precompute_interval_union_estimations(estimates, 1u);
 
-    EXPECT_RANGE_EQ(estimates, expected);
-}
+    std::vector<uint64_t> estimates(4);
 
-TEST_F(user_bin_sequence_test, precompute_interval_union_estimations_two_threads)
-{
-    std::vector<std::vector<uint64_t>> expected{{{500},{670,600},{670,670,700},{670,670,670,800}}};
+    this->precompute_union_estimates_for(estimates, 0);
+    EXPECT_RANGE_EQ(estimates, (vt{500, 0, 0, 0}));
 
-    std::vector<std::vector<uint64_t>> estimates{};
-    this->read_hll_files(data("")); // load hll files for test_filenames from data directory
-    this->precompute_interval_union_estimations(estimates, 2u);
+    this->precompute_union_estimates_for(estimates, 1);
+    EXPECT_RANGE_EQ(estimates, (vt{670, 600, 0, 0}));
 
-    EXPECT_RANGE_EQ(estimates, expected);
+    this->precompute_union_estimates_for(estimates, 2);
+    EXPECT_RANGE_EQ(estimates, (vt{670, 670, 700, 0}));
+
+    this->precompute_union_estimates_for(estimates, 3);
+    EXPECT_RANGE_EQ(estimates, (vt{670, 670, 670, 800}));
 }
 
 TEST_F(user_bin_sequence_test, random_shuffle)

--- a/test/api/sketch/user_bin_sequence_test.cpp
+++ b/test/api/sketch/user_bin_sequence_test.cpp
@@ -136,31 +136,31 @@ TEST_F(user_bin_sequence_test, read_hll_files_faulty_file)
     EXPECT_THROW(this->read_hll_files(tmp_file.get_path().parent_path()), std::runtime_error);
 }
 
-TEST_F(user_bin_sequence_test, estimate_interval_unions_error_no_sketches)
+TEST_F(user_bin_sequence_test, precompute_interval_union_estimations_error_no_sketches)
 {
     std::vector<std::vector<uint64_t>> estimates{};
 
-    EXPECT_THROW(this->estimate_interval_unions(estimates, 1u), std::runtime_error);
+    EXPECT_THROW(this->precompute_interval_union_estimations(estimates, 1u), std::runtime_error);
 }
 
-TEST_F(user_bin_sequence_test, estimate_interval_unions_one_thread)
+TEST_F(user_bin_sequence_test, precompute_interval_union_estimations_one_thread)
 {
     std::vector<std::vector<uint64_t>> expected{{{500},{670,600},{670,670,700},{670,670,670,800}}};
 
     std::vector<std::vector<uint64_t>> estimates{};
     this->read_hll_files(data("")); // load hll files for test_filenames from data directory
-    this->estimate_interval_unions(estimates, 1u);
+    this->precompute_interval_union_estimations(estimates, 1u);
 
     EXPECT_RANGE_EQ(estimates, expected);
 }
 
-TEST_F(user_bin_sequence_test, estimate_interval_unions_two_threads)
+TEST_F(user_bin_sequence_test, precompute_interval_union_estimations_two_threads)
 {
     std::vector<std::vector<uint64_t>> expected{{{500},{670,600},{670,670,700},{670,670,670,800}}};
 
     std::vector<std::vector<uint64_t>> estimates{};
     this->read_hll_files(data("")); // load hll files for test_filenames from data directory
-    this->estimate_interval_unions(estimates, 2u);
+    this->precompute_interval_union_estimations(estimates, 2u);
 
     EXPECT_RANGE_EQ(estimates, expected);
 }


### PR DESCRIPTION
This PR significantly lowers the memory consumption at the cost of performance (not tracked).

Instead of storing all interval union estimations in a matrix of size `#user bins x #user bins` we now only store a single vector of size `#user bins` when computing the current column in the DP algorithm.

When backtracking the optimal path, union estimations are computed again for certain merged bins but only if statistics are required so the performance drop is fine.