### PR TITLE
[FIX] Wrong t_max in output

### DIFF
--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -122,7 +122,7 @@ public:
                   << ((verbose) ? "## uncorr_size : The expected size of an tmax-HIBF without FPR correction\n" : "");
 
         // print column names
-        std::cout << "#tmax"      << '\t'
+        std::cout << "# tmax"     << '\t'
                   << "c_tmax"     << '\t'
                   << "l_tmax"     << '\t'
                   << "m_tmax"     << '\t'

--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -251,6 +251,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
     }
 
     std::cout << "# Best t_max (regarding expected query runtime): " << best_t_max << '\n';
+    config.tmax = best_t_max;
     return max_hibf_id;
 }
 

--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -208,7 +208,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
     std::cout << "## ### Parameters ###\n"
               << "## number of user bins = " << data.filenames.size() << '\n'
               << "## number of hash functions = " << config.num_hash_functions << '\n'
-              << "## false positive rate = " << config.false_positive_rate << "\n";
+              << "## false positive rate = " << config.false_positive_rate << '\n';
     hibf_statistics::print_header(config.output_verbose_statistics);
 
     double best_expected_HIBF_query_cost{std::numeric_limits<double>::infinity()};
@@ -250,7 +250,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
         }
     }
 
-    std::cout << "#Best t_max (regarding expected query runtime):" << best_t_max << '\n';
+    std::cout << "# Best t_max (regarding expected query runtime): " << best_t_max << '\n';
     return max_hibf_id;
 }
 

--- a/test/api/layout/execute_with_estimation_test.cpp
+++ b/test/api/layout/execute_with_estimation_test.cpp
@@ -108,6 +108,9 @@ R"expected_cout(## ### Parameters ###
 256	1.20	1.20	0.70	0.83	59KiB
 # Best t_max (regarding expected query runtime): 128
 )expected_cout");
+
+    std::string const layout_string{string_from_file(layout_file.get_path())};
+    EXPECT_NE(layout_string.find("\"tmax\": 128,"), std::string::npos);
 }
 
 TEST(execute_estimation_test, many_ubs_force_all)
@@ -155,6 +158,9 @@ R"expected_cout(## ### Parameters ###
 256	1.20	1.20	0.70	0.83	59KiB
 # Best t_max (regarding expected query runtime): 128
 )expected_cout");
+
+    std::string const layout_string{string_from_file(layout_file.get_path())};
+    EXPECT_NE(layout_string.find("\"tmax\": 128,"), std::string::npos);
 }
 
 TEST(execute_estimation_test, with_rearrangement)
@@ -229,4 +235,7 @@ R"expected_cout(## ### Parameters ###
 256	1.20	1.39	1.19	1.66	138KiB
 # Best t_max (regarding expected query runtime): 256
 )expected_cout");
+
+    std::string const layout_string{string_from_file(layout_file.get_path())};
+    EXPECT_NE(layout_string.find("\"tmax\": 256,"), std::string::npos);
 }

--- a/test/api/layout/execute_with_estimation_test.cpp
+++ b/test/api/layout/execute_with_estimation_test.cpp
@@ -53,9 +53,9 @@ R"expected_cout(## ### Parameters ###
 ## m_tmax : The estimated memory consumption for an tmax-HIBF, compared to an 64-HIBF
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
-#tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
+# tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
 64	1.00	1.00	1.00	1.00	17KiB
-#Best t_max (regarding expected query runtime):64
+# Best t_max (regarding expected query runtime): 64
 )expected_cout");
 
     EXPECT_EQ(testing::internal::GetCapturedStderr(), "[CHOPPER LAYOUT WARNING]: Your requested number of technical "
@@ -102,11 +102,11 @@ R"expected_cout(## ### Parameters ###
 ## m_tmax : The estimated memory consumption for an tmax-HIBF, compared to an 64-HIBF
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
-#tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
+# tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
 64	1.00	1.26	1.00	1.26	85KiB
 128	0.96	0.98	0.59	0.58	50KiB
 256	1.20	1.20	0.70	0.83	59KiB
-#Best t_max (regarding expected query runtime):128
+# Best t_max (regarding expected query runtime): 128
 )expected_cout");
 }
 
@@ -149,11 +149,11 @@ R"expected_cout(## ### Parameters ###
 ## m_tmax : The estimated memory consumption for an tmax-HIBF, compared to an 64-HIBF
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
-#tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
+# tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
 64	1.00	1.26	1.00	1.26	85KiB
 128	0.96	0.98	0.59	0.58	50KiB
 256	1.20	1.20	0.70	0.83	59KiB
-#Best t_max (regarding expected query runtime):128
+# Best t_max (regarding expected query runtime): 128
 )expected_cout");
 }
 
@@ -223,10 +223,10 @@ R"expected_cout(## ### Parameters ###
 ## m_tmax : The estimated memory consumption for an tmax-HIBF, compared to an 64-HIBF
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
-#tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
+# tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
 64	1.00	2.23	1.00	2.23	116KiB
 128	0.96	1.57	1.15	1.81	134KiB
 256	1.20	1.39	1.19	1.66	138KiB
-#Best t_max (regarding expected query runtime):256
+# Best t_max (regarding expected query runtime): 256
 )expected_cout");
 }

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -63,7 +63,7 @@ R"expected_cout(## ### Notation ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 ## uncorr_size : The expected size of an tmax-HIBF without FPR correction
-#tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
+# tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
 64	1.00	16.00	1.00	16.00	1KiB	1KiB	:0:1	:1:4	:395Bytes:790Bytes	:395Bytes:790Bytes	:4:8	:4:2	:0.00:100.00	:-:1	:-:1.00	:-:1.00	:-:1.00
 )expected_cout";
 

--- a/test/cli/cli_chopper_layout_statistics_test.cpp
+++ b/test/cli/cli_chopper_layout_statistics_test.cpp
@@ -34,7 +34,7 @@ R"expected_cout(## ### Notation ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 ## uncorr_size : The expected size of an tmax-HIBF without FPR correction
-#tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
+# tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
 64	1.00	1.26	1.00	1.26	85KiB	45KiB	:0:1	:1:12	:37KiB:48KiB	:37KiB:8KiB	:64:768	:64:64	:81.25:100.00	:1:32	:1.00:17.45	:1.00:9.02	:1.00:6.50
 )expected_cout";
 
@@ -88,10 +88,10 @@ R"expected_cout(## ### Parameters ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 ## uncorr_size : The expected size of an tmax-HIBF without FPR correction
-#tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
+# tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
 64	1.00	1.00	1.00	1.00	1MiB	1MiB	:0	:1	:1MiB	:1MiB	:64	:64	:100.00	:20	:6.40	:6.38	:3.62
 128	0.96	0.96	1.63	1.56	3MiB	2MiB	:0	:1	:3MiB	:2MiB	:128	:128	:100.00	:47	:12.80	:12.17	:5.96
-#Best t_max (regarding expected query runtime):128
+# Best t_max (regarding expected query runtime): 128
 )expected_cout";
 
     EXPECT_EQ(layout_result.exit_code, 0);


### PR DESCRIPTION
Commit 1 just adds some spaces. We usually use spaces...

Commit 2 sets the best tmax as tmax. The tests check whether the `"tmax": 256` line exists in the config.