### PR TITLE
[MISC] byte formatting

### DIFF
--- a/include/chopper/helper.hpp
+++ b/include/chopper/helper.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <string>
@@ -10,22 +11,62 @@ namespace chopper
 /*!\brief Returns the smallest natural number that is greater or equal to `value` and a multiplicative of 64.
 * \param[in] value The Input value that is smaller or equal to the return value.
 */
-[[nodiscard]] constexpr size_t next_multiple_of_64(size_t const value)
+[[nodiscard]] constexpr size_t next_multiple_of_64(size_t const value) noexcept
 {
     return ((value + 63) >> 6) << 6;
 }
 
 //!\brief Round bytes to the appropriate unit and convert to string with unit.
-[[nodiscard]] inline std::string byte_size_to_formatted_str(size_t bytes)
+[[nodiscard]] inline std::string byte_size_to_formatted_str(size_t const bytes)
 {
     size_t iterations{};
-    while (bytes >> 10 && iterations < 5)
+    size_t integer{bytes};
+
+    while (integer >> 10u && iterations < 6u)
     {
-        bytes >>= 10;
+        integer >>= 10u;
         ++iterations;
     }
 
-    std::string result{std::to_string(bytes)};
+    // While this is a bit more involved, we can avoid using floating point numbers.
+    auto first_decimal_position = [&]()
+    {
+        assert(iterations > 0u);
+        size_t decimal{bytes};
+        decimal -= integer << (iterations * 10u); // Substract bytes represented by integer, e.g. -5GiB
+        decimal >>= (iterations - 1u) * 10u; // Shift to next smallest unit, e.g. 800MiB
+        decimal = decimal * 1000u / 1024u; // Account for using decimal system, i.e. 800MiB != 0.8GiB
+        size_t const diff{decimal - (decimal / 100u) * 100u}; // We want to round up to 1 decimal position
+        uint32_t const round_up{diff >= 50u};
+        decimal += round_up * 100u - diff;
+        decimal /= 100u;
+        return decimal;
+    };
+
+    auto formatted_string = [&]()
+    {
+        static constexpr int8_t int_to_char_offset{'0'}; // int 0 as char: char{0 + 48} = '0'
+        size_t const decimal = iterations ? first_decimal_position() : 0u;
+        assert(decimal <= 10u);
+
+        if (!iterations) // No decimals for Bytes
+            return std::to_string(integer);
+        else if (decimal < 10u) // No need to round integer part
+            return std::to_string(integer) + '.' + static_cast<char>(decimal + int_to_char_offset);
+        else // Round integer part, e.g., 5.99 MiB should report 6.0 MiB
+        {
+            ++integer;
+            // Check whether rounding results in a change of unit, e.g. 1023.99MiB to 1.0GiB
+            if (integer >> 10u)
+            {
+                ++iterations;
+                integer >>= 10u;
+            }
+            return std::to_string(integer) + ".0";
+        }
+    };
+
+    std::string result{formatted_string()};
     switch (iterations)
     {
         case 0:
@@ -45,6 +86,9 @@ namespace chopper
             break;
         case 5:
             result += "PiB";
+            break;
+        default:
+            result += "EiB";
             break;
     }
 

--- a/test/api/helper_test.cpp
+++ b/test/api/helper_test.cpp
@@ -2,14 +2,29 @@
 
 #include <chopper/helper.hpp>
 
-TEST(byte_size_to_formatted_str, correct_output)
+TEST(byte_size_to_formatted_str, storage_unit)
 {
     // `ULL` means unsigned long long; ensures that shifting works since `55` will usually be a 32bit-int
     // `<< 10` is the same as `* 1024`, `<< 20` the same as `* 1024 * 1024`, and so on
-    EXPECT_EQ(chopper::byte_size_to_formatted_str(55ULL), std::string{"55Bytes"});
-    EXPECT_EQ(chopper::byte_size_to_formatted_str(55ULL << 10), std::string{"55KiB"});
-    EXPECT_EQ(chopper::byte_size_to_formatted_str(55ULL << 20), std::string{"55MiB"});
-    EXPECT_EQ(chopper::byte_size_to_formatted_str(55ULL << 30), std::string{"55GiB"});
-    EXPECT_EQ(chopper::byte_size_to_formatted_str(55ULL << 40), std::string{"55TiB"});
-    EXPECT_EQ(chopper::byte_size_to_formatted_str(55ULL << 50), std::string{"55PiB"});
+    EXPECT_EQ("8Bytes", chopper::byte_size_to_formatted_str(8ULL));
+    EXPECT_EQ("8.0KiB", chopper::byte_size_to_formatted_str(8ULL << 10));
+    EXPECT_EQ("8.0MiB", chopper::byte_size_to_formatted_str(8ULL << 20));
+    EXPECT_EQ("8.0GiB", chopper::byte_size_to_formatted_str(8ULL << 30));
+    EXPECT_EQ("8.0TiB", chopper::byte_size_to_formatted_str(8ULL << 40));
+    EXPECT_EQ("8.0PiB", chopper::byte_size_to_formatted_str(8ULL << 50));
+    EXPECT_EQ("8.0EiB", chopper::byte_size_to_formatted_str(8ULL << 60));
+}
+
+TEST(byte_size_to_formatted_str, rounding)
+{
+    EXPECT_EQ("5.8GiB", chopper::byte_size_to_formatted_str(6'174'015'488ULL));
+    EXPECT_EQ("5.7GiB", chopper::byte_size_to_formatted_str(6'174'015'487ULL));
+    // This is 1 bytes short of 1MiB. Rounding should change the unit from KiB to MiB.
+    EXPECT_EQ("1.0MiB", chopper::byte_size_to_formatted_str(1'048'575ULL));
+}
+
+TEST(byte_size_to_formatted_str, edge_cases)
+{
+    EXPECT_EQ("0Bytes", chopper::byte_size_to_formatted_str(0ULL));
+    EXPECT_EQ("16.0EiB", chopper::byte_size_to_formatted_str(std::numeric_limits<size_t>::max()));
 }

--- a/test/api/layout/execute_with_estimation_test.cpp
+++ b/test/api/layout/execute_with_estimation_test.cpp
@@ -54,7 +54,7 @@ R"expected_cout(## ### Parameters ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
-64	1.00	1.00	1.00	1.00	17KiB
+64	1.00	1.00	1.00	1.00	17.5KiB
 # Best t_max (regarding expected query runtime): 64
 )expected_cout");
 
@@ -103,9 +103,9 @@ R"expected_cout(## ### Parameters ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
-64	1.00	1.26	1.00	1.26	85KiB
-128	0.96	0.98	0.59	0.58	50KiB
-256	1.20	1.20	0.70	0.83	59KiB
+64	1.00	1.26	1.00	1.26	85.2KiB
+128	0.96	0.98	0.59	0.58	50.3KiB
+256	1.20	1.20	0.70	0.83	59.3KiB
 # Best t_max (regarding expected query runtime): 128
 )expected_cout");
 
@@ -153,9 +153,9 @@ R"expected_cout(## ### Parameters ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
-64	1.00	1.26	1.00	1.26	85KiB
-128	0.96	0.98	0.59	0.58	50KiB
-256	1.20	1.20	0.70	0.83	59KiB
+64	1.00	1.26	1.00	1.26	85.2KiB
+128	0.96	0.98	0.59	0.58	50.3KiB
+256	1.20	1.20	0.70	0.83	59.3KiB
 # Best t_max (regarding expected query runtime): 128
 )expected_cout");
 
@@ -230,9 +230,9 @@ R"expected_cout(## ### Parameters ###
 ## (l*m)_tmax : Computed by l_tmax * m_tmax
 ## size : The expected total size of an tmax-HIBF
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size
-64	1.00	2.23	1.00	2.23	116KiB
-128	0.96	1.57	1.15	1.81	134KiB
-256	1.20	1.39	1.19	1.66	138KiB
+64	1.00	2.23	1.00	2.23	116.5KiB
+128	0.96	1.57	1.15	1.81	134.3KiB
+256	1.20	1.39	1.19	1.66	138.7KiB
 # Best t_max (regarding expected query runtime): 256
 )expected_cout");
 

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -64,7 +64,7 @@ R"expected_cout(## ### Notation ###
 ## size : The expected total size of an tmax-HIBF
 ## uncorr_size : The expected size of an tmax-HIBF without FPR correction
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
-64	1.00	16.00	1.00	16.00	1KiB	1KiB	:0:1	:1:4	:395Bytes:790Bytes	:395Bytes:790Bytes	:4:8	:4:2	:0.00:100.00	:-:1	:-:1.00	:-:1.00	:-:1.00
+64	1.00	16.00	1.00	16.00	1.2KiB	1.2KiB	:0:1	:1:4	:395Bytes:790Bytes	:395Bytes:790Bytes	:4:8	:4:2	:0.00:100.00	:-:1	:-:1.00	:-:1.00	:-:1.00
 )expected_cout";
 
     EXPECT_EQ(summary, expected_cout);

--- a/test/cli/cli_chopper_layout_statistics_test.cpp
+++ b/test/cli/cli_chopper_layout_statistics_test.cpp
@@ -35,7 +35,7 @@ R"expected_cout(## ### Notation ###
 ## size : The expected total size of an tmax-HIBF
 ## uncorr_size : The expected size of an tmax-HIBF without FPR correction
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
-64	1.00	1.26	1.00	1.26	85KiB	45KiB	:0:1	:1:12	:37KiB:48KiB	:37KiB:8KiB	:64:768	:64:64	:81.25:100.00	:1:32	:1.00:17.45	:1.00:9.02	:1.00:6.50
+64	1.00	1.26	1.00	1.26	85.2KiB	45.4KiB	:0:1	:1:12	:37.0KiB:48.2KiB	:37.0KiB:8.3KiB	:64:768	:64:64	:81.25:100.00	:1:32	:1.00:17.45	:1.00:9.02	:1.00:6.50
 )expected_cout";
 
     EXPECT_EQ(layout_result.exit_code, 0);
@@ -89,8 +89,8 @@ R"expected_cout(## ### Parameters ###
 ## size : The expected total size of an tmax-HIBF
 ## uncorr_size : The expected size of an tmax-HIBF without FPR correction
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
-64	1.00	1.00	1.00	1.00	1MiB	1MiB	:0	:1	:1MiB	:1MiB	:64	:64	:100.00	:20	:6.40	:6.38	:3.62
-128	0.96	0.96	1.63	1.56	3MiB	2MiB	:0	:1	:3MiB	:2MiB	:128	:128	:100.00	:47	:12.80	:12.17	:5.96
+64	1.00	1.00	1.00	1.00	1.9MiB	1.8MiB	:0	:1	:1.9MiB	:1.8MiB	:64	:64	:100.00	:20	:6.40	:6.38	:3.62
+128	0.96	0.96	1.63	1.56	3.1MiB	2.4MiB	:0	:1	:3.1MiB	:2.4MiB	:128	:128	:100.00	:47	:12.80	:12.17	:5.96
 # Best t_max (regarding expected query runtime): 128
 )expected_cout";
 


### PR DESCRIPTION
Todo: 
- [x] Adapt unit in tests.

Questions:
- [x] Rounding. `5.75GiB -> 5.8GiB`, but `5.75GiB - 1Bytes -> 5.7GiB`
- [x] Remove decimal from bytes?
---

I added Exbibyte such that I avoid unintended behaviour for big numbers