### PR TITLE
Make not building measure_hyperloglog the default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries (chopper_lib INTERFACE "chopper_interface" "chopper_count_
 add_executable (chopper chopper.cpp)
 target_link_libraries (chopper "chopper_lib")
 
-add_executable (measure_hyperloglog measure_hyperloglog.cpp)
+add_executable (measure_hyperloglog EXCLUDE_FROM_ALL measure_hyperloglog.cpp)
 target_link_libraries (measure_hyperloglog "chopper_interface")
 
 install (TARGETS chopper_count_lib chopper_layout_lib ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
I noticed that the target binary `measure_hyperloglog` is always built, even when you only build chopper as a submodule (e.g. for raptor). I created this binary to do some measurements for my bachelor thesis. I think it makes sense to not build it by default.