### PR TITLE
[TEST] Enable warnings

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -107,7 +107,7 @@ jobs:
           mkdir build
           cd build
           cmake ../chopper -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                           -DCMAKE_CXX_FLAGS="-Werror -Wno-interference-size ${{ matrix.cxx_flags }}"
+                           -DCMAKE_CXX_FLAGS="-Wno-interference-size ${{ matrix.cxx_flags }}"
 
       - name: Build tests
         env:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -91,7 +91,7 @@ jobs:
           mkdir build
           cd build
           cmake ../chopper -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                           -DCMAKE_CXX_FLAGS="-Werror -Wno-interference-size ${{ matrix.cxx_flags }}" \
+                           -DCMAKE_CXX_FLAGS="-Wno-interference-size ${{ matrix.cxx_flags }}" \
 
       - name: Build tests
         env:

--- a/include/chopper/layout/filenames_data_input.hpp
+++ b/include/chopper/layout/filenames_data_input.hpp
@@ -43,7 +43,7 @@ inline auto read_filename_data_file(data_store & data, configuration const & con
 
         // read kmer_count
         ++ptr; // skip tab
-        size_t tmp;
+        size_t tmp{};
         auto res = std::from_chars(ptr, buffer_end, tmp);
         data.kmer_counts.push_back(tmp);
         ptr = res.ptr;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries (chopper "chopper_lib")
 
 add_executable (measure_hyperloglog EXCLUDE_FROM_ALL measure_hyperloglog.cpp)
 target_link_libraries (measure_hyperloglog "chopper_interface")
+target_compile_options (measure_hyperloglog PRIVATE "-Werror")
 
 install (TARGETS chopper_layout_lib ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install (TARGETS chopper RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ macro (add_app_test test_filename test_alternative)
     # Create the test target.
     add_executable (${target} ${test_filename})
     target_link_libraries (${target} "${PROJECT_NAME}_lib" seqan3::seqan3 gtest gtest_main)
+    target_compile_options (${target} PRIVATE "-Werror")
 
     # Make seqan3::test available for both cli and api tests.
     target_include_directories (${target} PUBLIC "${SEQAN3_CLONE_DIR}/test/include")
@@ -85,5 +86,7 @@ else ()
     add_subdirectory (cli)
     add_subdirectory (coverage)
 endif ()
+
+add_dependencies (cli_test measure_hyperloglog)
 
 message (STATUS "${FontBold}You can run `make test` to build and run tests.${FontReset}")

--- a/test/cmake/chopper_require_test.cmake
+++ b/test/cmake/chopper_require_test.cmake
@@ -8,26 +8,32 @@
 cmake_minimum_required (VERSION 3.15)
 
 # Exposes the google-test targets `gtest` and `gtest_main`.
+# CMake 3.24: https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_TRY_FIND_PACKAGE_MODE
 macro (chopper_require_test)
     enable_testing ()
 
-    set (CHOPPER_GTEST_GIT_TAG
-         "8d51dc50eb7e7698427fed81b85edad0e032112e"
-         CACHE STRING "googletest commit to use")
+    set (gtest_version "1.12.1")
+    set (gtest_git_tag "release-${gtest_version}")
 
-    message (STATUS "Fetch Google Test:")
+    find_package (GTest ${gtest_version} EXACT QUIET)
 
-    include (FetchContent)
-    FetchContent_Declare (
-        gtest_fetch_content
-        GIT_REPOSITORY "https://github.com/google/googletest.git"
-        GIT_TAG "${CHOPPER_GTEST_GIT_TAG}")
-    option (BUILD_GMOCK "" OFF)
-    FetchContent_MakeAvailable (gtest_fetch_content)
+    if (NOT GTest_FOUND)
+        message (STATUS "Fetching Google Test ${gtest_version}")
+
+        include (FetchContent)
+        FetchContent_Declare (gtest_fetch_content
+                              GIT_REPOSITORY "https://github.com/google/googletest.git"
+                              GIT_TAG "${gtest_git_tag}"
+        )
+        option (BUILD_GMOCK "" OFF)
+        option (INSTALL_GTEST "" OFF)
+        FetchContent_MakeAvailable (gtest_fetch_content)
+    else ()
+        message (STATUS "Found Google Test ${gtest_version}")
+    endif ()
 
     if (NOT TARGET gtest_build)
         add_custom_target (gtest_build DEPENDS gtest_main gtest)
-        target_compile_options ("gtest_main" PUBLIC "-w")
-        target_compile_options ("gtest" PUBLIC "-w")
     endif ()
+
 endmacro ()


### PR DESCRIPTION
Don't override flags with `-w`, and make cli_test dependent on `measure_hyperloglog` such that it is built when building tests.
Also, don't set `-Werror` globally, as we don't care about warnings when building gtest.