### PR TITLE
[MISC] Write statistics to file instead of std::cout.

### DIFF
--- a/include/chopper/layout/hibf_statistics.hpp
+++ b/include/chopper/layout/hibf_statistics.hpp
@@ -113,14 +113,14 @@ public:
     }
 
     //!\brief Prints a column names of the summary to the command line.
-    static void print_header(bool const verbose = true)
+    static void print_header_to(std::ostream & stream, bool const verbose = true)
     {
         // print column names explanation in header
-        std::cout << "## ### Notation ###\n"
+        stream << "## ### Notation ###\n"
                   << "## X-IBF = An IBF with X number of bins.\n"
                   << "## X-HIBF = An HIBF with tmax = X, e.g a maximum of X technical bins on each level.\n";
 
-        std::cout << "## ### Column Description ###\n"
+        stream << "## ### Column Description ###\n"
                      "## tmax : The maximum number of technical bin on each level\n"
                      "## c_tmax : The technical extra cost of querying an tmax-IBF, compared to 64-IBF\n"
                      "## l_tmax : The estimated query cost for an tmax-HIBF, compared to an 64-HIBF\n"
@@ -130,22 +130,22 @@ public:
                   << ((verbose) ? "## uncorr_size : The expected size of an tmax-HIBF without FPR correction\n" : "");
 
         // print column names
-        std::cout << "# tmax" << '\t' << "c_tmax" << '\t' << "l_tmax" << '\t' << "m_tmax" << '\t' << "(l*m)_tmax"
+        stream << "# tmax" << '\t' << "c_tmax" << '\t' << "l_tmax" << '\t' << "m_tmax" << '\t' << "(l*m)_tmax"
                   << '\t' << "size";
 
         if (verbose) // uncorrected size and add level statistics
         {
-            std::cout << '\t' << "uncorr_size" << '\t' << "level" << '\t' << "num_ibfs" << '\t' << "level_size" << '\t'
+            stream << '\t' << "uncorr_size" << '\t' << "level" << '\t' << "num_ibfs" << '\t' << "level_size" << '\t'
                       << "level_size_no_corr" << '\t' << "total_num_tbs" << '\t' << "avg_num_tbs" << '\t'
                       << "split_tb_percentage" << '\t' << "max_split_tb" << '\t' << "avg_split_tb" << '\t'
                       << "max_factor" << '\t' << "avg_factor";
         }
 
-        std::cout << '\n';
+        stream << '\n';
     }
 
     //!\brief Prints a tab-separated summary of the statistics of this HIBF to the command line.
-    void print_summary(size_t & t_max_64_memory, bool const verbose = true)
+    void print_summary_to(size_t & t_max_64_memory, std::ostream & stream, bool const verbose = true)
     {
         if (summaries.empty())
             finalize();
@@ -156,7 +156,7 @@ public:
         double const relative_memory_size = total_hibf_size_in_byte() / static_cast<double>(t_max_64_memory);
         double const query_time_memory_usage_prod = expected_HIBF_query_cost * relative_memory_size;
 
-        std::cout << std::fixed << std::setprecision(2);
+        stream << std::fixed << std::setprecision(2);
 
         std::string level_str, num_ibfs_str, level_size_str, level_size_no_corr_str, total_num_tbs_str, avg_num_tbs_str,
             split_tb_percentage_str, max_split_tb_str, avg_split_tb_str, max_factor_str, avg_factor_str;
@@ -229,9 +229,9 @@ public:
             }
         }
 
-        std::cout << std::fixed << std::setprecision(2);
+        stream << std::fixed << std::setprecision(2);
 
-        std::cout /*        tmax */ << config.tmax
+        stream /*        tmax */ << config.tmax
                                     << '\t'
                                     /*      c_tmax */
                                     << chopper::layout::ibf_query_cost::interpolated(config.tmax,
@@ -252,10 +252,10 @@ public:
         if (verbose)
         {
             // uncorrected FPR
-            std::cout /*uncorr. size */ << to_formatted_BF_size(total_size_no_corr) << '\t';
+            stream /*uncorr. size */ << to_formatted_BF_size(total_size_no_corr) << '\t';
 
             // per level statistics:
-            std::cout /* level               */ << level_str
+            stream /* level               */ << level_str
                                                 << '\t'
                                                 /* num_ibfs            */
                                                 << num_ibfs_str

--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -49,11 +49,13 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
     // with -determine-best-tmax the algorithm is executed multiple times and result with the minimum
     // expected query costs are written to the standard output
 
-    std::cout << "## ### Parameters ###\n"
+    std::ofstream file_out{config.output_filename.string() + ".stats"};
+
+    file_out << "## ### Parameters ###\n"
               << "## number of user bins = " << data.filenames.size() << '\n'
               << "## number of hash functions = " << config.num_hash_functions << '\n'
               << "## false positive rate = " << config.false_positive_rate << '\n';
-    hibf_statistics::print_header_to(std::cout, config.output_verbose_statistics);
+    hibf_statistics::print_header_to(file_out, config.output_verbose_statistics);
 
     double best_expected_HIBF_query_cost{std::numeric_limits<double>::infinity()};
     size_t best_t_max{};
@@ -77,7 +79,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
 
         global_stats.finalize();
 
-        global_stats.print_summary_to(t_max_64_memory, std::cout, config.output_verbose_statistics);
+        global_stats.print_summary_to(t_max_64_memory, file_out, config.output_verbose_statistics);
 
         // Use result if better than previous one.
         if (global_stats.expected_HIBF_query_cost < best_expected_HIBF_query_cost)
@@ -94,7 +96,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
         }
     }
 
-    std::cout << "# Best t_max (regarding expected query runtime): " << best_t_max << '\n';
+    file_out << "# Best t_max (regarding expected query runtime): " << best_t_max << '\n';
     config.tmax = best_t_max;
     return max_hibf_id;
 }

--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -53,7 +53,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
               << "## number of user bins = " << data.filenames.size() << '\n'
               << "## number of hash functions = " << config.num_hash_functions << '\n'
               << "## false positive rate = " << config.false_positive_rate << '\n';
-    hibf_statistics::print_header(config.output_verbose_statistics);
+    hibf_statistics::print_header_to(std::cout, config.output_verbose_statistics);
 
     double best_expected_HIBF_query_cost{std::numeric_limits<double>::infinity()};
     size_t best_t_max{};
@@ -77,7 +77,7 @@ size_t determine_best_number_of_technical_bins(chopper::layout::data_store & dat
 
         global_stats.finalize();
 
-        global_stats.print_summary(t_max_64_memory, config.output_verbose_statistics);
+        global_stats.print_summary_to(t_max_64_memory, std::cout, config.output_verbose_statistics);
 
         // Use result if better than previous one.
         if (global_stats.expected_HIBF_query_cost < best_expected_HIBF_query_cost)
@@ -146,8 +146,8 @@ int execute(chopper::configuration & config)
 
         if (config.output_verbose_statistics)
         {
-            global_stats.print_header();
-            global_stats.print_summary(dummy);
+            global_stats.print_header_to(std::cout);
+            global_stats.print_summary_to(dummy, std::cout);
         }
     }
 

--- a/test/api/layout/execute_with_estimation_test.cpp
+++ b/test/api/layout/execute_with_estimation_test.cpp
@@ -13,6 +13,7 @@ TEST(execute_estimation_test, few_ubs)
 {
     seqan3::test::tmp_filename const input_prefix{"test"};
     seqan3::test::tmp_filename const layout_file{"layout.tsv"};
+    std::filesystem::path const stats_file{layout_file.get_path().string() + ".stats"};
 
     {
         std::ofstream fout{input_prefix.get_path().string() + ".count"};
@@ -34,12 +35,15 @@ TEST(execute_estimation_test, few_ubs)
     config.output_filename = layout_file.get_path();
     chopper::detail::apply_prefix(config.output_prefix, config.count_filename, config.sketch_directory);
 
-    testing::internal::CaptureStdout();
     testing::internal::CaptureStderr();
 
     chopper::layout::execute(config);
 
-    EXPECT_EQ(testing::internal::GetCapturedStdout(),
+    ASSERT_TRUE(std::filesystem::exists(stats_file));
+
+    std::string const written_file{string_from_file(stats_file)};
+
+    EXPECT_EQ(written_file,
               R"expected_cout(## ### Parameters ###
 ## number of user bins = 8
 ## number of hash functions = 2
@@ -70,6 +74,7 @@ TEST(execute_estimation_test, many_ubs)
 {
     seqan3::test::tmp_filename const input_prefix{"test"};
     seqan3::test::tmp_filename const layout_file{"layout.tsv"};
+    std::filesystem::path const stats_file{layout_file.get_path().string() + ".stats"};
 
     {
         // There are 20 files with a count of {100,200,300,400} each. There are 16 files with count 500.
@@ -86,11 +91,13 @@ TEST(execute_estimation_test, many_ubs)
     config.output_filename = layout_file.get_path();
     chopper::detail::apply_prefix(config.output_prefix, config.count_filename, config.sketch_directory);
 
-    testing::internal::CaptureStdout();
-
     chopper::layout::execute(config);
 
-    EXPECT_EQ(testing::internal::GetCapturedStdout(),
+    ASSERT_TRUE(std::filesystem::exists(stats_file));
+
+    std::string const written_file{string_from_file(stats_file)};
+
+    EXPECT_EQ(written_file,
               R"expected_cout(## ### Parameters ###
 ## number of user bins = 96
 ## number of hash functions = 2
@@ -120,6 +127,7 @@ TEST(execute_estimation_test, many_ubs_force_all)
 {
     seqan3::test::tmp_filename const input_prefix{"test"};
     seqan3::test::tmp_filename const layout_file{"layout.tsv"};
+    std::filesystem::path const stats_file{layout_file.get_path().string() + ".stats"};
 
     {
         // There are 20 files with a count of {100,200,300,400} each. There are 16 files with count 500.
@@ -137,11 +145,13 @@ TEST(execute_estimation_test, many_ubs_force_all)
     config.output_filename = layout_file.get_path();
     chopper::detail::apply_prefix(config.output_prefix, config.count_filename, config.sketch_directory);
 
-    testing::internal::CaptureStdout();
-
     chopper::layout::execute(config);
 
-    EXPECT_EQ(testing::internal::GetCapturedStdout(),
+    ASSERT_TRUE(std::filesystem::exists(stats_file));
+
+    std::string const written_file{string_from_file(stats_file)};
+
+    EXPECT_EQ(written_file,
               R"expected_cout(## ### Parameters ###
 ## number of user bins = 96
 ## number of hash functions = 2
@@ -172,6 +182,7 @@ TEST(execute_estimation_test, with_rearrangement)
     seqan3::test::tmp_filename const prefix{"test"};
     seqan3::test::tmp_filename const input_file{"test.tsv"};
     seqan3::test::tmp_filename const layout_file{"layout.tsv"};
+    std::filesystem::path const stats_file{layout_file.get_path().string() + ".stats"};
 
     {
         std::ofstream fout{input_file.get_path()};
@@ -214,11 +225,13 @@ TEST(execute_estimation_test, with_rearrangement)
     config.output_filename = layout_file.get_path();
     chopper::detail::apply_prefix(config.output_prefix, config.count_filename, config.sketch_directory);
 
-    testing::internal::CaptureStdout();
-
     chopper::layout::execute(config);
 
-    EXPECT_EQ(testing::internal::GetCapturedStdout(),
+    ASSERT_TRUE(std::filesystem::exists(stats_file));
+
+    std::string const written_file{string_from_file(stats_file)};
+
+    EXPECT_EQ(written_file,
               R"expected_cout(## ### Parameters ###
 ## number of user bins = 196
 ## number of hash functions = 2

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -44,9 +44,9 @@ TEST(hibf_statistics, only_merged_on_top_level)
 
     testing::internal::CaptureStdout();
 
-    stats.print_header();
+    stats.print_header_to(std::cout);
     size_t max_64{};
-    stats.print_summary(max_64);
+    stats.print_summary_to(max_64, std::cout);
     std::cout.flush();
 
     std::string summary = testing::internal::GetCapturedStdout();

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -121,6 +121,7 @@ TEST(execute_test, chopper_layout_statistics_determine_best_bins)
 {
     seqan3::test::tmp_filename const input_prefixname{"test"};
     seqan3::test::tmp_filename const binning_filename{"output.binning"};
+    std::filesystem::path const stats_file{binning_filename.get_path().string() + ".stats"};
 
     // Write count data to file.
     {
@@ -147,11 +148,7 @@ TEST(execute_test, chopper_layout_statistics_determine_best_bins)
                                   .output_verbose_statistics = true};
     chopper::detail::apply_prefix(config.output_prefix, config.count_filename, config.sketch_directory);
 
-    testing::internal::CaptureStdout();
-    testing::internal::CaptureStderr();
     chopper::layout::execute(config);
-    std::string layout_result_stdout = testing::internal::GetCapturedStdout();
-    std::string layout_result_stderr = testing::internal::GetCapturedStderr();
 
     std::string expected_cout =
         R"expected_cout(## ### Parameters ###
@@ -175,6 +172,9 @@ TEST(execute_test, chopper_layout_statistics_determine_best_bins)
 # Best t_max (regarding expected query runtime): 128
 )expected_cout";
 
-    EXPECT_EQ(layout_result_stdout, expected_cout) << layout_result_stdout;
-    EXPECT_EQ(layout_result_stderr, std::string{});
+    ASSERT_TRUE(std::filesystem::exists(stats_file));
+
+    std::string const written_file{string_from_file(stats_file)};
+
+    EXPECT_EQ(written_file, expected_cout) << written_file;
 }


### PR DESCRIPTION
One step to make things easier to handle once we try to move everything to seqan3