### PR TITLE
[MISC] Output sketches on cli command.

### DIFF
--- a/include/chopper/set_up_parser.hpp
+++ b/include/chopper/set_up_parser.hpp
@@ -209,16 +209,14 @@ inline void set_up_parser(sharg::parser & parser, chopper::configuration & confi
                           "and has no effect.",
                       .hidden = true});
 
-    parser.add_flag(
-        config.disable_sketch_output,
+    parser.add_option(
+        config.sketch_directory,
         sharg::config{
-            .short_id = '\0',
-            .long_id = "disable-sketch-output",
+            .long_id = "output-sketches-to",
             .description =
-                "Although the sketches will improve the layout, you might want to disable "
-                "writing the sketch files to disk. Doing so will save disk space. However, you cannot use either "
-                "--estimate-unions or --rearrange-user-bins in chopper layout without the sketches. Note that "
-                "this option does not decrease run time as sketches have to be computed either way."});
+                "If you supply a directory path with this option, the hyperloglog sketches of your input will be "
+                "stored in the respective path; one .hll file per input file.",
+            .advanced = true});
 
     parser.add_flag(config.debug,
                     sharg::config{.short_id = '\0',

--- a/src/chopper.cpp
+++ b/src/chopper.cpp
@@ -21,6 +21,8 @@ int main(int argc, char const * argv[])
     try
     {
         parser.parse();
+
+        config.disable_sketch_output = !parser.is_option_set("output-sketches-to");
     }
     catch (sharg::parser_error const & ext) // the user did something wrong
     {

--- a/test/cli/cli_chopper_pipeline_test.cpp
+++ b/test/cli/cli_chopper_pipeline_test.cpp
@@ -16,7 +16,6 @@
 TEST_F(cli_test, chopper_layout)
 {
     std::string const seq_filename = data("small.fa");
-    std::filesystem::path const sketch_prefix = "chopper_sketch";
     seqan3::test::tmp_directory tmp_dir{};
     std::filesystem::path const taxa_filename{tmp_dir.path()/"data.tsv"};
     std::filesystem::path const binning_filename{tmp_dir.path()/"output.binning"};
@@ -35,7 +34,6 @@ TEST_F(cli_test, chopper_layout)
                                          "15",
                                          "--threads",
                                          "2",
-                                         "--disable-sketch-output",
                                          "--input-file",
                                          taxa_filename.c_str(),
                                          "--tmax",
@@ -97,7 +95,6 @@ TEST_F(cli_test, chopper_layout)
     }
 }
 
-// check if each chopper submodule can work with the output of the other
 TEST_F(cli_test, chopper_layout2)
 {
     std::string const seq1_filename = data("seq1.fa");
@@ -107,7 +104,6 @@ TEST_F(cli_test, chopper_layout2)
     seqan3::test::tmp_directory tmp_dir{};
     std::filesystem::path const taxa_filename{tmp_dir.path()/"data.tsv"};
     std::filesystem::path const binning_filename{tmp_dir.path()/"output.binning"};
-    std::filesystem::path const sketch_prefix = "chopper_sketch";
 
     // we need to have filenames from the user
     {
@@ -147,7 +143,7 @@ TEST_F(cli_test, chopper_layout2)
                                 "##        },\n"
                                 "##        \"k\": 19,\n"
                                 "##        \"sketch_bits\": 12,\n"
-                                "##        \"disable_sketch_output\": false,\n"
+                                "##        \"disable_sketch_output\": true,\n"
                                 "##        \"precomputed_files\": false,\n"
                                 "##        \"output_filename\": {\n"
                                 "##            \"value0\": \""


### PR DESCRIPTION
Instead of always writing the sketches and disabling that with `--disable-sketch-output`, the sketches will now never be written unless the user specifically sets `--output-sketches-to PATH` on the command line.