### PR TITLE
[FIX] Serialisation of configuration

### DIFF
--- a/include/chopper/configuration.hpp
+++ b/include/chopper/configuration.hpp
@@ -98,7 +98,7 @@ private:
     template <typename archive_t>
     void serialize(archive_t & archive)
     {
-        uint32_t const version{2};
+        uint32_t version{2};
         archive(CEREAL_NVP(version));
 
         archive(CEREAL_NVP(data_file));


### PR DESCRIPTION
`version` can't be const for deserialisation