### PR TITLE
[MISC] Make precompute_union_estimates_for static.

### DIFF
--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -208,7 +208,10 @@ private:
             double const ub_cardinality = static_cast<double>(current_weight);
 
             if (!config.disable_estimate_union)
-                data->sketch_toolbox.precompute_union_estimates_for(data->union_estimates, j);
+                sketch::toolbox::precompute_union_estimates_for(data->union_estimates,
+                                                                data->sketches,
+                                                                data->kmer_counts,
+                                                                j);
 
             for (size_t i = 1; i < num_technical_bins; ++i)
             {

--- a/test/api/sketch/toolbox_test.cpp
+++ b/test/api/sketch/toolbox_test.cpp
@@ -149,23 +149,19 @@ TEST_F(toolbox_test, read_hll_files_into_faulty_file)
 
 TEST_F(toolbox_test, precompute_union_estimates_for)
 {
-    using vt = std::vector<uint64_t>;
-
     std::vector<uint64_t> estimates(4);
 
-    chopper::sketch::toolbox ubs{test_filenames, test_kmer_counts, test_sketches};
+    chopper::sketch::toolbox::precompute_union_estimates_for(estimates, test_sketches, test_kmer_counts, 0);
+    EXPECT_RANGE_EQ(estimates, (std::vector<uint64_t>{500, 0, 0, 0}));
 
-    ubs.precompute_union_estimates_for(estimates, 0);
-    EXPECT_RANGE_EQ(estimates, (vt{500, 0, 0, 0}));
+    chopper::sketch::toolbox::precompute_union_estimates_for(estimates, test_sketches, test_kmer_counts, 1);
+    EXPECT_RANGE_EQ(estimates, (std::vector<uint64_t>{670, 600, 0, 0}));
 
-    ubs.precompute_union_estimates_for(estimates, 1);
-    EXPECT_RANGE_EQ(estimates, (vt{670, 600, 0, 0}));
+    chopper::sketch::toolbox::precompute_union_estimates_for(estimates, test_sketches, test_kmer_counts, 2);
+    EXPECT_RANGE_EQ(estimates, (std::vector<uint64_t>{670, 670, 700, 0}));
 
-    ubs.precompute_union_estimates_for(estimates, 2);
-    EXPECT_RANGE_EQ(estimates, (vt{670, 670, 700, 0}));
-
-    ubs.precompute_union_estimates_for(estimates, 3);
-    EXPECT_RANGE_EQ(estimates, (vt{670, 670, 670, 800}));
+    chopper::sketch::toolbox::precompute_union_estimates_for(estimates, test_sketches, test_kmer_counts, 3);
+    EXPECT_RANGE_EQ(estimates, (std::vector<uint64_t>{670, 670, 670, 800}));
 }
 
 TEST_F(toolbox_test, random_shuffle)


### PR DESCRIPTION
Makes no sense to store an instance of `chopper::sketch::toolbox` just to use something that could be used as a "free function" also. 