### PR TITLE
[MISC] Rip out hibf_statistic from layout algorithm.

### DIFF
--- a/include/chopper/data_store.hpp
+++ b/include/chopper/data_store.hpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include <chopper/configuration.hpp>
-#include <chopper/layout/hibf_statistics.hpp>
 #include <chopper/layout/layout.hpp>
 #include <chopper/sketch/toolbox.hpp>
 
@@ -36,9 +35,6 @@ struct data_store
      */
     //!\brief The desired maximum false positive rate of the resulting index.
     double const false_positive_rate{};
-
-    //!\brief An object starting at the top level IBF to collecting statistics about the HIBF on the way.
-    layout::hibf_statistics::level * stats{nullptr};
 
     //!\brief The layout that is build by layout::hierarchical_binning.
     layout::layout * hibf_layout;

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -97,9 +97,7 @@ public:
         // print_matrix(ll_matrix, num_technical_bins, num_user_bins, max_size_t);
         // print_matrix(trace, num_technical_bins, num_user_bins, std::make_pair(max_size_t, max_size_t));
 
-        size_t const max_bin_idx = backtracking(trace);
-
-        return max_bin_idx;
+        return backtracking(trace);
     }
 
 private:

--- a/include/chopper/layout/hierarchical_binning.hpp
+++ b/include/chopper/layout/hierarchical_binning.hpp
@@ -97,7 +97,9 @@ public:
         // print_matrix(ll_matrix, num_technical_bins, num_user_bins, max_size_t);
         // print_matrix(trace, num_technical_bins, num_user_bins, std::make_pair(max_size_t, max_size_t));
 
-        return backtracking(trace);
+        size_t const max_bin_idx = backtracking(trace);
+
+        return max_bin_idx;
     }
 
 private:
@@ -355,13 +357,6 @@ private:
                                                           number_of_bins,
                                                           bin_id);
 
-                // add split bin to ibf statistics
-                if (data->stats)
-                {
-                    std::vector<size_t> user_bin_indices{data->positions[trace_j]};
-                    data->stats->bins.emplace_back(hibf_statistics::bin_kind::split, number_of_bins, user_bin_indices);
-                }
-
                 // std::cout << "split " << trace_j << " into " << number_of_bins << ": " << kmer_count_per_bin << std::endl;
 
                 update_max_id(high_level_max_id, high_level_max_size, bin_id, kmer_count_per_bin);
@@ -410,13 +405,6 @@ private:
                                                       number_of_tbs,
                                                       bin_id);
 
-            // add split bin to ibf statistics
-            if (data->stats)
-            {
-                std::vector<size_t> user_bin_indices{data->positions[0]};
-                data->stats->bins.emplace_back(hibf_statistics::bin_kind::split, number_of_tbs, user_bin_indices);
-            }
-
             update_max_id(high_level_max_id, high_level_max_size, bin_id, average_bin_size);
             // std::cout << "split " << trace_j << " into " << trace_i << ": " << kmer_count / number_of_tbs << std::endl;
         }
@@ -447,18 +435,6 @@ private:
     void process_merged_bin(data_store & libf_data, size_t const bin_id) const
     {
         update_libf_data(libf_data, bin_id);
-
-        // add merged bin to ibf statistics
-        if (data->stats)
-        {
-            std::vector<size_t> user_bin_indices{};
-            for (size_t pos : libf_data.positions)
-                user_bin_indices.push_back(pos);
-
-            hibf_statistics::bin & bin_stats =
-                data->stats->bins.emplace_back(hibf_statistics::bin_kind::merged, 1ul, user_bin_indices);
-            libf_data.stats = &bin_stats.child_level;
-        }
 
         // now do the binning for the low-level IBF:
         size_t const lower_max_bin = add_lower_level(libf_data);

--- a/include/chopper/layout/simple_binning.hpp
+++ b/include/chopper/layout/simple_binning.hpp
@@ -214,13 +214,6 @@ public:
                                                       number_of_bins,
                                                       bin_id);
 
-            // add split bin to ibf statistics
-            if (data->stats)
-            {
-                std::vector<size_t> user_bin_indices{data->positions[trace_j]};
-                data->stats->bins.emplace_back(hibf_statistics::bin_kind::split, number_of_bins, user_bin_indices);
-            }
-
             if (kmer_count_per_bin > max_size)
             {
                 max_id = bin_id;
@@ -237,13 +230,6 @@ public:
         size_t const kmer_count_per_bin = (kmer_count + trace_i - 1) / trace_i;
 
         data->hibf_layout->user_bins.emplace_back(data->positions[0], data->previous.bin_indices, trace_i, bin_id);
-
-        // add split bin to ibf statistics
-        if (data->stats)
-        {
-            std::vector<size_t> user_bin_indices{data->positions[0]};
-            data->stats->bins.emplace_back(hibf_statistics::bin_kind::split, trace_i, user_bin_indices);
-        }
 
         if (kmer_count_per_bin > max_size)
         {

--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -6,6 +6,7 @@
 
 #include <chopper/configuration.hpp>
 #include <chopper/layout/compute_fp_correction.hpp>
+#include <chopper/layout/hibf_statistics.hpp>
 #include <chopper/layout/hierarchical_binning.hpp>
 #include <chopper/layout/ibf_query_cost.hpp>
 #include <chopper/layout/output.hpp>
@@ -56,14 +57,12 @@ size_t determine_best_number_of_technical_bins(chopper::data_store & data, chopp
         data.hibf_layout = &tmp_layout;
         data.previous = chopper::data_store::previous_level{}; // reset previous IBF, s.t. data refers to top level IBF
 
-        chopper::layout::hibf_statistics global_stats{config, data.fp_correction, data.sketches, data.kmer_counts};
-        data.stats = &global_stats.top_level_ibf;
-
         // execute the actual algorithm
         size_t const max_hibf_id_tmp = chopper::layout::hierarchical_binning{data, config}.execute();
 
+        chopper::layout::hibf_statistics global_stats{config, data.fp_correction, data.sketches, data.kmer_counts};
+        global_stats.hibf_layout = *data.hibf_layout;
         global_stats.finalize();
-
         global_stats.print_summary_to(t_max_64_memory, file_out, config.output_verbose_statistics);
 
         // Use result if better than previous one.
@@ -118,14 +117,14 @@ int execute(chopper::configuration & config, std::vector<std::string> const & fi
     }
     else
     {
-        chopper::layout::hibf_statistics global_stats{config, data.fp_correction, data.sketches, data.kmer_counts};
-        data.stats = &global_stats.top_level_ibf;
         size_t dummy{};
 
         max_hibf_id = chopper::layout::hierarchical_binning{data, config}.execute(); // just execute once
 
         if (config.output_verbose_statistics)
         {
+            chopper::layout::hibf_statistics global_stats{config, data.fp_correction, data.sketches, data.kmer_counts};
+            global_stats.hibf_layout = *data.hibf_layout;
             global_stats.print_header_to(std::cout);
             global_stats.print_summary_to(dummy, std::cout);
         }

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -42,7 +42,7 @@ TEST(hibf_statistics, only_merged_on_top_level)
 {
     // parameters for this test HIBF
     size_t const num_top_level_bins = 4u;
-    size_t const top_level_num_contained_user_bins = 2u;
+    // size_t const top_level_num_contained_user_bins = 2u;
     size_t const lower_level_split_bin_span = 1u;
 
     chopper::configuration config{}; // default config
@@ -61,17 +61,11 @@ TEST(hibf_statistics, only_merged_on_top_level)
 
     for (size_t i = 0; i < num_top_level_bins; ++i)
     {
-        chopper::layout::hibf_statistics::bin & bin =
-            stats.top_level_ibf.bins.emplace_back(chopper::layout::hibf_statistics::bin_kind::merged,
-                                                  1u, // merged bin always is a single technical bin
-                                                  std::vector<size_t>{0, 1});
+        stats.hibf_layout.max_bins.emplace_back(std::vector<size_t>{0u}, 0u);
+        stats.hibf_layout.max_bins.emplace_back(std::vector<size_t>{1u}, 0u);
 
-        for (size_t j = 0; j < top_level_num_contained_user_bins; ++j)
-        {
-            bin.child_level.bins.emplace_back(chopper::layout::hibf_statistics::bin_kind::split,
-                                              lower_level_split_bin_span,
-                                              std::vector<size_t>{j % 2});
-        }
+        stats.hibf_layout.user_bins.emplace_back(0u, std::vector<size_t>{0u}, 2u, 0u);
+        stats.hibf_layout.user_bins.emplace_back(1u, std::vector<size_t>{1u}, 2u, 0u);
     }
 
     testing::internal::CaptureStdout();
@@ -95,7 +89,7 @@ TEST(hibf_statistics, only_merged_on_top_level)
 ## size : The expected total size of an tmax-HIBF
 ## uncorr_size : The expected size of an tmax-HIBF without FPR correction
 # tmax	c_tmax	l_tmax	m_tmax	(l*m)_tmax	size	uncorr_size	level	num_ibfs	level_size	level_size_no_corr	total_num_tbs	avg_num_tbs	split_tb_percentage	max_split_tb	avg_split_tb	max_factor	avg_factor
-64	1.00	8.00	1.00	8.00	790Bytes	790Bytes	:0:1	:1:4	:395Bytes:395Bytes	:395Bytes:395Bytes	:4:8	:4:2	:0.00:100.00	:-:1	:-:1.00	:-:1.00	:-:1.00
+64	1.00	8.00	1.00	8.00	979Bytes	790Bytes	:0:1	:1:2	:395Bytes:584Bytes	:395Bytes:395Bytes	:2:16	:2:8	:0.00:100.00	:-:2	:-:2.00	:-:1.46	:-:1.48
 )expected_cout";
 
     EXPECT_EQ(summary, expected_cout);

--- a/test/api/layout/hibf_statistics_test.cpp
+++ b/test/api/layout/hibf_statistics_test.cpp
@@ -42,7 +42,6 @@ TEST(hibf_statistics, only_merged_on_top_level)
 {
     // parameters for this test HIBF
     size_t const num_top_level_bins = 4u;
-    // size_t const top_level_num_contained_user_bins = 2u;
     size_t const lower_level_split_bin_span = 1u;
 
     chopper::configuration config{}; // default config

--- a/test/api/layout/hierarchical_binning_test.cpp
+++ b/test/api/layout/hierarchical_binning_test.cpp
@@ -19,12 +19,9 @@ TEST(hierarchical_binning_test, small_example)
     config.disable_estimate_union = true; // also disables rearrangement
 
     chopper::layout::layout hibf_layout{};
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
     std::vector<size_t> kmer_counts{500, 1000, 500, 500, 500, 500, 500, 500};
 
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
-                             .kmer_counts = kmer_counts};
+    chopper::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = kmer_counts};
 
     data.fp_correction = chopper::layout::compute_fp_correction(0.05, 2, config.tmax);
     chopper::layout::hierarchical_binning algo{data, config};
@@ -52,11 +49,8 @@ TEST(hierarchical_binning_test, another_example)
     config.disable_estimate_union = true; // also disables rearrangement
 
     chopper::layout::layout hibf_layout{};
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
     std::vector<size_t> kmer_counts{50, 1000, 1000, 50, 5, 10, 10, 5};
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
-                             .kmer_counts = kmer_counts};
+    chopper::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = kmer_counts};
 
     data.fp_correction = chopper::layout::compute_fp_correction(0.05, 2, config.tmax);
 
@@ -85,11 +79,8 @@ TEST(hierarchical_binning_test, high_level_max_bin_id_is_0)
     config.disable_estimate_union = true; // also disables rearrangement
 
     chopper::layout::layout hibf_layout{};
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
     std::vector<size_t> kmer_counts{500, 500, 500, 500};
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
-                             .kmer_counts = kmer_counts};
+    chopper::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = kmer_counts};
 
     data.fp_correction = chopper::layout::compute_fp_correction(0.05, 2, config.tmax);
 
@@ -112,11 +103,8 @@ TEST(hierarchical_binning_test, knuts_example)
     config.disable_estimate_union = true; // also disables rearrangement
 
     chopper::layout::layout hibf_layout{};
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
     std::vector<size_t> kmer_counts{60, 600, 1000, 800, 800};
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
-                             .kmer_counts = kmer_counts};
+    chopper::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = kmer_counts};
 
     data.fp_correction = chopper::layout::compute_fp_correction(0.05, 2, config.tmax);
 
@@ -142,11 +130,8 @@ TEST(hierarchical_binning_test, four_level_hibf)
     config.disable_estimate_union = true; // also disables rearrangement
 
     chopper::layout::layout hibf_layout{};
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
     std::vector<size_t> kmer_counts{11090, 5080, 3040, 1020, 510, 500};
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
-                             .kmer_counts = kmer_counts};
+    chopper::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = kmer_counts};
 
     data.fp_correction = chopper::layout::compute_fp_correction(0.05, 2, config.tmax);
 
@@ -177,11 +162,8 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin)
     config.disable_estimate_union = true; // also disables rearrangement
 
     chopper::layout::layout hibf_layout{};
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
     std::vector<size_t> kmer_counts{500, 500, 500, 500};
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
-                             .kmer_counts = kmer_counts};
+    chopper::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = kmer_counts};
 
     data.fp_correction = chopper::layout::compute_fp_correction(0.05, 2, config.tmax);
 
@@ -207,11 +189,8 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin_and_leads_to_recursive_call)
     config.disable_estimate_union = true; // also disables rearrangement
 
     chopper::layout::layout hibf_layout{};
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
     std::vector<size_t> kmer_counts{500, 500, 500, 500, 500, 500, 500, 500};
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
-                             .kmer_counts = kmer_counts};
+    chopper::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = kmer_counts};
 
     data.fp_correction = chopper::layout::compute_fp_correction(0.05, 2, config.tmax);
 

--- a/test/api/layout/simple_binning_test.cpp
+++ b/test/api/layout/simple_binning_test.cpp
@@ -11,14 +11,10 @@
 TEST(simple_binning_test, small_example)
 {
     chopper::layout::layout hibf_layout;
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
 
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
+    chopper::data_store data{.hibf_layout = &hibf_layout,
                              .kmer_counts = {100, 40, 20, 20},
                              .fp_correction = std::vector<double>(65, 1.0)};
-
-    // data.stats = &global_stats_dummy.top_level_ibf;
 
     chopper::layout::simple_binning algo{data, 9};
     size_t max_bin = algo.execute();
@@ -32,10 +28,8 @@ TEST(simple_binning_test, small_example)
 TEST(simple_binning_test, uniform_distribution)
 {
     chopper::layout::layout hibf_layout;
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
 
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
+    chopper::data_store data{.hibf_layout = &hibf_layout,
                              .kmer_counts = {20, 20, 20, 20},
                              .fp_correction = std::vector<double>(65, 1.0)};
 
@@ -51,10 +45,8 @@ TEST(simple_binning_test, uniform_distribution)
 TEST(simple_binning_test, user_bins_must_be_smaller_than_technical_bins)
 {
     chopper::layout::layout hibf_layout;
-    chopper::layout::hibf_statistics global_stats_dummy{{}, {}, {}, {}};
 
-    chopper::data_store data{.stats = &global_stats_dummy.top_level_ibf,
-                             .hibf_layout = &hibf_layout,
+    chopper::data_store data{.hibf_layout = &hibf_layout,
                              .kmer_counts = {100, 40, 20, 20},
                              .fp_correction = std::vector<double>(65, 1.0)};
 


### PR DESCRIPTION
Maybe the last big step, separating chopper stuff from just the layout algorithm that will move to the HIBF lib. Statistics will not move with it.