### PR TITLE
[MISC] Adds a chopper count util executable.

### DIFF
--- a/include/chopper/sketch/execute.hpp
+++ b/include/chopper/sketch/execute.hpp
@@ -79,7 +79,7 @@ execute(configuration & config, std::vector<std::string> const & filenames, std:
 
         assert(filenames.size() == sketches.size());
         for (size_t i = 0; i < filenames.size(); ++i)
-            write_sketch_file(filenames[i], sketches[i], config);
+            write_sketch_file(filenames[i], sketches[i], config.sketch_directory);
     }
 
     return 0;

--- a/include/chopper/sketch/output.hpp
+++ b/include/chopper/sketch/output.hpp
@@ -26,10 +26,10 @@ inline void write_count_file_line(std::pair<std::string, std::vector<std::string
 
 inline void write_sketch_file(std::string const & filename,
                               chopper::sketch::hyperloglog const & sketch,
-                              configuration const & config)
+                              std::filesystem::path output_directory)
 {
     // For one file in the cluster, the file stem is used with the .hll ending
-    std::filesystem::path path = config.sketch_directory / std::filesystem::path(filename).stem();
+    std::filesystem::path path = output_directory / std::filesystem::path(filename).stem();
     path += ".hll";
     std::ofstream hll_fout(path, std::ios::binary);
     sketch.dump(hll_fout);

--- a/include/chopper/sketch/read_data_file.hpp
+++ b/include/chopper/sketch/read_data_file.hpp
@@ -10,12 +10,12 @@
 namespace chopper::sketch
 {
 
-inline void read_data_file(configuration const & config, std::vector<std::string> & filenames)
+inline void read_data_file(std::string const & input_filename, std::vector<std::string> & filenames)
 {
-    std::ifstream fin{config.data_file.string()};
+    std::ifstream fin{input_filename};
 
     if (!fin.good() || !fin.is_open())
-        throw std::runtime_error{"Could not open data file " + config.data_file.string() + " for reading."};
+        throw std::runtime_error{"Could not open data file " + input_filename + " for reading."};
 
     std::string line;
     while (std::getline(fin, line))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,5 +23,9 @@ add_executable (measure_hyperloglog EXCLUDE_FROM_ALL measure_hyperloglog.cpp)
 target_link_libraries (measure_hyperloglog "chopper_interface")
 target_compile_options (measure_hyperloglog PRIVATE "-Werror")
 
+add_executable (chopper_count EXCLUDE_FROM_ALL count.cpp)
+target_link_libraries (chopper_count "chopper_interface")
+target_compile_options (chopper_count PRIVATE "-Werror")
+
 install (TARGETS chopper_layout_lib ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install (TARGETS chopper RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/chopper.cpp
+++ b/src/chopper.cpp
@@ -36,7 +36,7 @@ int main(int argc, char const * argv[])
     std::vector<size_t> kmer_counts{};
     std::vector<chopper::sketch::hyperloglog> sketches{};
 
-    chopper::sketch::read_data_file(config, filenames);
+    chopper::sketch::read_data_file(config.data_file.string(), filenames);
 
     try
     {

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -17,7 +17,7 @@ int main(int argc, char const * argv[])
     chopper::configuration config;
     std::string counts_path;
 
-    parser.add_option(config.input_data,
+    parser.add_option(config.data_file,
                       sharg::config{.short_id = 'i',
                                     .long_id = "input-file",
                                     .description = "Fasta formatted file with sequences.",
@@ -27,7 +27,7 @@ int main(int argc, char const * argv[])
                                     .long_id = "output-file",
                                     .description = "File where the output is written to in tsv format.",
                                     .required = true});
-    parser.add_option(config.kmer_size,
+    parser.add_option(config.k,
                       sharg::config{.short_id = 'k',
                                     .long_id = "kmer-size",
                                     .description = "The size of the k-mers of which the hash values are computed."});
@@ -47,7 +47,7 @@ int main(int argc, char const * argv[])
         sharg::config{.short_id = 'b',
                       .long_id = "hll-bits",
                       .description = "Adds an integer value which is tested as HyperLogLog bits parameter.",
-                      .advances = true});
+                      .advanced = true});
 
     try
     {
@@ -65,7 +65,7 @@ int main(int argc, char const * argv[])
     std::vector<size_t> kmer_counts{};
     std::vector<chopper::sketch::hyperloglog> sketches{};
 
-    chopper::sketch::read_data_file(config.input_data, filenames);
+    chopper::sketch::read_data_file(config.data_file, filenames);
 
     chopper::sketch::execute(config, filenames, sketches);
     chopper::sketch::estimate_kmer_counts(sketches, kmer_counts);

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -7,9 +7,9 @@
 
 #include <sharg/parser.hpp>
 
-#include <chopper/sketch/read_data_file.hpp>
-#include <chopper/sketch/execute.hpp>
 #include <chopper/sketch/estimate_kmer_counts.hpp>
+#include <chopper/sketch/execute.hpp>
+#include <chopper/sketch/read_data_file.hpp>
 
 struct cli_args
 {

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -1,0 +1,94 @@
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <sharg/parser.hpp>
+
+#include <chopper/sketch/read_data_file.hpp>
+#include <chopper/sketch/execute.hpp>
+#include <chopper/sketch/estimate_kmer_counts.hpp>
+
+struct cli_args
+{
+    std::filesystem::path input_path{};
+    std::filesystem::path counts_path{};
+    //!\brief The kmer size to hash the input sequences before computing a HyperLogLog sketch from them.
+    uint8_t kmer_size{19};
+    //!\brief The number of bits the HyperLogLog sketch should use to distribute the values into bins.
+    uint8_t sketch_bits{12};
+    //!\brief The name for the output directory when writing sketches to disk.
+    std::filesystem::path sketch_directory{};
+};
+
+int main(int argc, char const * argv[])
+{
+    sharg::parser parser{"measure_hyperloglog", argc, argv, sharg::update_notifications::off};
+
+    cli_args args{};
+
+    parser.add_option(args.input_path,
+                      sharg::config{.short_id = 'i',
+                                    .long_id = "input-file",
+                                    .description = "Fasta formatted file with sequences.",
+                                    .required = true});
+    parser.add_option(args.counts_path,
+                      sharg::config{.short_id = 'o',
+                                    .long_id = "output-file",
+                                    .description = "File where the output is written to in tsv format.",
+                                    .required = true});
+    parser.add_option(args.kmer_size,
+                      sharg::config{.short_id = 'k',
+                                    .long_id = "kmer-size",
+                                    .description = "The size of the k-mers of which the hash values are computed."});
+
+    parser.add_option(
+        config.sketch_directory,
+        sharg::config{
+            .long_id = "output-sketches-to",
+            .description =
+                "If you supply a directory path with this option, the hyperloglog sketches of your input will be "
+                "stored in the respective path; one .hll file per input file.",
+            .default_message = "None"});
+
+    parser.add_section("Advanced Options:");
+    parser.add_option(
+        args.sketch_bits,
+        sharg::config{.short_id = 'b',
+                      .long_id = "hll-bits",
+                      .description = "Adds an integer value which is tested as HyperLogLog bits parameter.",
+                      .advances = true});
+
+    try
+    {
+        parser.parse();
+    }
+    catch (sharg::parser_error const & ext)
+    {
+        std::cerr << "[COMMAND LINE INPUT ERROR] " << ext.what() << std::endl;
+        return -1;
+    }
+
+    std::ofstream fout{args.counts_path};
+
+    std::vector<std::string> filenames{};
+    std::vector<size_t> kmer_counts{};
+    std::vector<chopper::sketch::hyperloglog> sketches{};
+
+    chopper::sketch::read_data_file(args.input_path, filenames);
+
+    chopper::sketch::execute(config, filenames, sketches);
+    chopper::sketch::estimate_kmer_counts(sketches, kmer_counts);
+
+    if (!args.sketch_directory.empty() && !std::filesystem::exists(config.sketch_directory))
+        std::filesystem::create_directory(config.sketch_directory);
+
+    for (size_t i = 0; i < filenames.size(); ++i)
+    {
+        fout << filenames[i] << '\t' << kmer_counts[i] << '\n';
+        if (!args.sketch_directory.empty())
+            write_sketch_file(filenames[i], sketches[i], args.sketch_directory);
+    }
+}

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -73,15 +73,6 @@ int main(int argc, char const * argv[])
     chopper::sketch::execute(config, filenames, sketches);
     chopper::sketch::estimate_kmer_counts(sketches, kmer_counts);
 
-    bool const output_sketches = parser.is_option_set("output-sketches-to");
-
-    if (output_sketches && !std::filesystem::exists(config.sketch_directory))
-        std::filesystem::create_directory(config.sketch_directory);
-
     for (size_t i = 0; i < filenames.size(); ++i)
-    {
         fout << filenames[i] << '\t' << kmer_counts[i] << '\n';
-        if (output_sketches)
-            write_sketch_file(filenames[i], sketches[i], config.sketch_directory);
-    }
 }

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -62,6 +62,8 @@ int main(int argc, char const * argv[])
         return -1;
     }
 
+    config.disable_sketch_output = !parser.is_option_set("output-sketches-to");
+
     std::ofstream fout{counts_path};
 
     std::vector<std::string> filenames{};

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -73,13 +73,15 @@ int main(int argc, char const * argv[])
     chopper::sketch::execute(config, filenames, sketches);
     chopper::sketch::estimate_kmer_counts(sketches, kmer_counts);
 
-    if (!config.sketch_directory.empty() && !std::filesystem::exists(config.sketch_directory))
+    bool const output_sketches = parser.is_option_set("output-sketches-to");
+
+    if (output_sketches && !std::filesystem::exists(config.sketch_directory))
         std::filesystem::create_directory(config.sketch_directory);
 
     for (size_t i = 0; i < filenames.size(); ++i)
     {
         fout << filenames[i] << '\t' << kmer_counts[i] << '\n';
-        if (!config.sketch_directory.empty())
+        if (output_sketches)
             write_sketch_file(filenames[i], sketches[i], config.sketch_directory);
     }
 }

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -31,7 +31,10 @@ int main(int argc, char const * argv[])
                       sharg::config{.short_id = 'k',
                                     .long_id = "kmer-size",
                                     .description = "The size of the k-mers of which the hash values are computed."});
-
+    parser.add_option(config.threads,
+                      sharg::config{.short_id = 't',
+                                    .long_id = "threads",
+                                    .description = "The number of threads to use for sketching."});
     parser.add_option(
         config.sketch_directory,
         sharg::config{

--- a/src/count.cpp
+++ b/src/count.cpp
@@ -1,45 +1,33 @@
-#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include <sharg/parser.hpp>
 
+#include <chopper/configuration.hpp>
 #include <chopper/sketch/estimate_kmer_counts.hpp>
 #include <chopper/sketch/execute.hpp>
 #include <chopper/sketch/read_data_file.hpp>
 
-struct cli_args
-{
-    std::filesystem::path input_path{};
-    std::filesystem::path counts_path{};
-    //!\brief The kmer size to hash the input sequences before computing a HyperLogLog sketch from them.
-    uint8_t kmer_size{19};
-    //!\brief The number of bits the HyperLogLog sketch should use to distribute the values into bins.
-    uint8_t sketch_bits{12};
-    //!\brief The name for the output directory when writing sketches to disk.
-    std::filesystem::path sketch_directory{};
-};
-
 int main(int argc, char const * argv[])
 {
-    sharg::parser parser{"measure_hyperloglog", argc, argv, sharg::update_notifications::off};
+    sharg::parser parser{"chopper_count", argc, argv, sharg::update_notifications::off};
 
-    cli_args args{};
+    chopper::configuration config;
+    std::string counts_path;
 
-    parser.add_option(args.input_path,
+    parser.add_option(config.input_data,
                       sharg::config{.short_id = 'i',
                                     .long_id = "input-file",
                                     .description = "Fasta formatted file with sequences.",
                                     .required = true});
-    parser.add_option(args.counts_path,
+    parser.add_option(counts_path,
                       sharg::config{.short_id = 'o',
                                     .long_id = "output-file",
                                     .description = "File where the output is written to in tsv format.",
                                     .required = true});
-    parser.add_option(args.kmer_size,
+    parser.add_option(config.kmer_size,
                       sharg::config{.short_id = 'k',
                                     .long_id = "kmer-size",
                                     .description = "The size of the k-mers of which the hash values are computed."});
@@ -55,7 +43,7 @@ int main(int argc, char const * argv[])
 
     parser.add_section("Advanced Options:");
     parser.add_option(
-        args.sketch_bits,
+        config.sketch_bits,
         sharg::config{.short_id = 'b',
                       .long_id = "hll-bits",
                       .description = "Adds an integer value which is tested as HyperLogLog bits parameter.",
@@ -71,24 +59,24 @@ int main(int argc, char const * argv[])
         return -1;
     }
 
-    std::ofstream fout{args.counts_path};
+    std::ofstream fout{counts_path};
 
     std::vector<std::string> filenames{};
     std::vector<size_t> kmer_counts{};
     std::vector<chopper::sketch::hyperloglog> sketches{};
 
-    chopper::sketch::read_data_file(args.input_path, filenames);
+    chopper::sketch::read_data_file(config.input_data, filenames);
 
     chopper::sketch::execute(config, filenames, sketches);
     chopper::sketch::estimate_kmer_counts(sketches, kmer_counts);
 
-    if (!args.sketch_directory.empty() && !std::filesystem::exists(config.sketch_directory))
+    if (!config.sketch_directory.empty() && !std::filesystem::exists(config.sketch_directory))
         std::filesystem::create_directory(config.sketch_directory);
 
     for (size_t i = 0; i < filenames.size(); ++i)
     {
         fout << filenames[i] << '\t' << kmer_counts[i] << '\n';
-        if (!args.sketch_directory.empty())
-            write_sketch_file(filenames[i], sketches[i], args.sketch_directory);
+        if (!config.sketch_directory.empty())
+            write_sketch_file(filenames[i], sketches[i], config.sketch_directory);
     }
 }

--- a/test/api/sketch/read_data_file_test.cpp
+++ b/test/api/sketch/read_data_file_test.cpp
@@ -3,26 +3,22 @@
 #include <sstream>
 #include <vector>
 
-#include <chopper/configuration.hpp>
 #include <chopper/sketch/read_data_file.hpp>
 
 #include "../api_test.hpp"
 
 TEST(read_data_file_test, file_open_error)
 {
-    chopper::configuration config{};
     std::vector<std::string> filenames{};
-    config.data_file = data("non_existing.file");
-    EXPECT_THROW(chopper::sketch::read_data_file(config, filenames), std::runtime_error);
+    EXPECT_THROW(chopper::sketch::read_data_file(data("non_existing.file"), filenames), std::runtime_error);
 }
 
 TEST(read_data_file_test, small_example)
 {
     chopper::configuration config;
     std::vector<std::string> filenames{};
-    config.data_file = data("seqinfo.tsv");
 
-    chopper::sketch::read_data_file(config, filenames);
+    chopper::sketch::read_data_file(data("seqinfo.tsv"), filenames);
 
     std::vector<std::string> expected_filenames{"file1", "file2", "file3", "file4", "file5"};
     EXPECT_RANGE_EQ(filenames, expected_filenames);


### PR DESCRIPTION
Currently chopper computes the layout. Sometimes (and I have a use case currently), I still need the sizes of the user bins and want to compute them efficiently. This PR therefore adds an executable that basically is the former `chopper count` that outputs a count file and if requested also the sketches.