### PR TITLE
[TEST] Add compute_ibf_size test.

### DIFF
--- a/src/util/display_layout/compute_ibf_size.hpp
+++ b/src/util/display_layout/compute_ibf_size.hpp
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/chopper/blob/main/LICENSE.md
+// ---------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+
+#include <hibf/build/bin_size_in_bits.hpp>
+#include <hibf/build/build_data.hpp>
+#include <hibf/contrib/robin_hood.hpp>
+#include <hibf/layout/graph.hpp>
+
+void update_parent_kmers(robin_hood::unordered_flat_set<uint64_t> & parent_kmers,
+                         robin_hood::unordered_flat_set<uint64_t> const & kmers)
+{
+    parent_kmers.insert(kmers.begin(), kmers.end());
+}
+
+size_t compute_ibf_size(robin_hood::unordered_flat_set<uint64_t> & parent_kmers,
+                        robin_hood::unordered_flat_set<uint64_t> & kmers,
+                        size_t const number_of_bins,
+                        seqan::hibf::layout::graph::node const & ibf_node,
+                        seqan::hibf::build::build_data & data,
+                        size_t const current_hibf_level)
+{
+    size_t const kmers_per_bin = std::ceil(static_cast<double>(kmers.size()) / number_of_bins);
+    size_t const bin_size =
+        std::ceil(seqan::hibf::build::bin_size_in_bits({.fpr = data.config.maximum_false_positive_rate,
+                                                        .hash_count = data.config.number_of_hash_functions,
+                                                        .elements = kmers_per_bin})
+                  * data.fpr_correction[number_of_bins]);
+
+    size_t const ibf_size = ibf_node.number_of_technical_bins * bin_size;
+
+    if (current_hibf_level > 0 /* not top level */)
+        update_parent_kmers(parent_kmers, kmers);
+
+    return ibf_size;
+}

--- a/test/api/display_layout/CMakeLists.txt
+++ b/test/api/display_layout/CMakeLists.txt
@@ -1,0 +1,11 @@
+# ---------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/chopper/blob/main/LICENSE.md
+# ---------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.18)
+
+add_api_test (compute_ibf_size_test.cpp)
+target_include_directories (compute_ibf_size_test PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../../../src/util/display_layout")

--- a/test/api/display_layout/compute_ibf_size_test.cpp
+++ b/test/api/display_layout/compute_ibf_size_test.cpp
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/chopper/blob/main/LICENSE.md
+// ---------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <compute_ibf_size.hpp>
+
+#include <hibf/build/construct_ibf.hpp> // for construct_ibf
+#include <hibf/layout/compute_fpr_correction.hpp>
+
+TEST(compute_ibf_size_test, merged_bin_is_max_bin)
+{
+    size_t const number_of_bins = 1;
+    size_t const current_hibf_level = 0;
+
+    robin_hood::unordered_flat_set<uint64_t> parent_kmers;
+    robin_hood::unordered_flat_set<uint64_t> kmers;
+
+    for (size_t i = 0; i < 1000; ++i)
+        kmers.insert(i);
+
+    seqan::hibf::layout::graph::node ibf_node{
+        .children = {seqan::hibf::layout::graph::node{}}, // one merged bin
+        .parent_bin_index = 0,
+        .max_bin_index = 0,
+        .number_of_technical_bins = 64,
+        .favourite_child_idx = 0, // max bin is a merged bin and it is the first in `children`
+        .remaining_records = {}   // not needed for compute_ibf_size
+    };
+
+    double fpr = 0.0001;
+    size_t hash = 2;
+    size_t tmax = 64;
+
+    seqan::hibf::build::build_data data{
+        .config = {.number_of_user_bins = 123,
+                   .number_of_hash_functions = hash,
+                   .maximum_false_positive_rate = fpr,
+                   .threads = 1,
+                   .tmax = tmax},
+        .fpr_correction = seqan::hibf::layout::compute_fpr_correction({.fpr = fpr, .hash_count = hash, .t_max = tmax})};
+
+    auto ibf = seqan::hibf::build::construct_ibf(parent_kmers, kmers, number_of_bins, ibf_node, data, true);
+
+    auto ibf_size = compute_ibf_size(parent_kmers, kmers, number_of_bins, ibf_node, data, current_hibf_level);
+
+    EXPECT_EQ(ibf_size, ibf.bit_size());
+    EXPECT_TRUE(parent_kmers.empty());
+}
+
+TEST(compute_ibf_size_test, split_bin_is_max_bin)
+{
+    size_t const number_of_bins = 4;
+    size_t const current_hibf_level = 1;
+
+    robin_hood::unordered_flat_set<uint64_t> parent_kmers;
+    robin_hood::unordered_flat_set<uint64_t> kmers;
+
+    for (size_t i = 0; i < 1000; ++i)
+        kmers.insert(i);
+
+    seqan::hibf::layout::graph::node ibf_node{
+        .children = {seqan::hibf::layout::graph::node{}}, // one merged bin
+        .parent_bin_index = 0,
+        .max_bin_index = 0,
+        .number_of_technical_bins = 64,
+        .favourite_child_idx = std::nullopt, // max bin is a split bin
+        .remaining_records = {}              // not needed for compute_ibf_size
+    };
+
+    double fpr = 0.0001;
+    size_t hash = 2;
+    size_t tmax = 64;
+
+    seqan::hibf::build::build_data data{
+        .config = {.number_of_user_bins = 123,
+                   .number_of_hash_functions = hash,
+                   .maximum_false_positive_rate = fpr,
+                   .threads = 1,
+                   .tmax = tmax},
+        .fpr_correction = seqan::hibf::layout::compute_fpr_correction({.fpr = fpr, .hash_count = hash, .t_max = tmax})};
+
+    auto ibf = seqan::hibf::build::construct_ibf(parent_kmers, kmers, number_of_bins, ibf_node, data, true);
+
+    auto ibf_size = compute_ibf_size(parent_kmers, kmers, number_of_bins, ibf_node, data, current_hibf_level);
+
+    EXPECT_EQ(ibf_size, ibf.bit_size());
+    EXPECT_FALSE(parent_kmers.empty());
+}


### PR DESCRIPTION
This makes sure that display_layout in chopper does not compute wrong sizes but is in sync with the hibf lib function `construct_ibf`

Todo:
- [x] Find a better way to include `compute_ibf_size.hpp` in test 