### PR TITLE
[MISC] Add workaround for gcc13's bogus memmov warnings

### DIFF
--- a/include/chopper/workarounds.hpp
+++ b/include/chopper/workarounds.hpp
@@ -7,13 +7,29 @@
 
 #pragma once
 
+#if defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+#    define CHOPPER_COMPILER_IS_GCC 1
+#else
+#    define CHOPPER_COMPILER_IS_GCC 0
+#endif
+
 /*!\brief Workaround bogus memcpy errors in GCC 12. (Wrestrict and Wstringop-overflow)
  * \see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105545
  */
 #ifndef CHOPPER_WORKAROUND_GCC_BOGUS_MEMCPY
-#    if defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER) && (__GNUC__ == 12)
+#    if CHOPPER_COMPILER_IS_GCC && (__GNUC__ == 12)
 #        define CHOPPER_WORKAROUND_GCC_BOGUS_MEMCPY 1
 #    else
 #        define CHOPPER_WORKAROUND_GCC_BOGUS_MEMCPY 0
+#    endif
+#endif
+
+/*!\brief Workaround bogus memmov errors in GCC 13. (Warray-bounds and Wstringop-overflow)
+ */
+#ifndef CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
+#    if CHOPPER_COMPILER_IS_GCC && (__GNUC__ == 13)
+#        define CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV 1
+#    else
+#        define CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV 0
 #    endif
 #endif

--- a/src/layout/hibf_statistics.cpp
+++ b/src/layout/hibf_statistics.cpp
@@ -387,7 +387,15 @@ void hibf_statistics::collect_bins()
 
             if (!found_merged_bin)
             {
+#if CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Warray-bounds="
+#    pragma GCC diagnostic ignored "-Wstringop-overflow="
+#endif // CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
                 ibf.bins.emplace_back(hibf_statistics::bin_kind::merged, 1, std::vector<size_t>{user_bin_info.idx});
+#if CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
+#    pragma GCC diagnostic pop
+#endif // CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
                 ibf.bins.back().tb_index = target_tb_index;
                 auto next = prev;
                 next.push_back(target_tb_index);
@@ -398,9 +406,17 @@ void hibf_statistics::collect_bins()
 
         // emplace a split bin at last since every user bin is on its lowest level single or split
         auto & ibf = ibfs[id_to_pos.at(prev)];
+#if CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Warray-bounds="
+#    pragma GCC diagnostic ignored "-Wstringop-overflow="
+#endif // CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
         ibf.bins.emplace_back(hibf_statistics::bin_kind::split,
                               user_bin_info.number_of_technical_bins,
                               std::vector<size_t>{user_bin_info.idx});
+#if CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
+#    pragma GCC diagnostic pop
+#endif // CHOPPER_WORKAROUND_GCC_BOGUS_MEMMOV
         ibf.bins.back().tb_index = user_bin_info.storage_TB_id;
     }
 


### PR DESCRIPTION
For example, Debug mode and O2