### PR TITLE
[MISC] determine_best_tmax should not compute its own sketches.

### DIFF
--- a/include/chopper/layout/determine_best_number_of_technical_bins.hpp
+++ b/include/chopper/layout/determine_best_number_of_technical_bins.hpp
@@ -16,7 +16,9 @@
 namespace chopper::layout
 {
 
-std::pair<seqan::hibf::layout::layout, std::vector<seqan::hibf::sketch::hyperloglog>>
-determine_best_number_of_technical_bins(chopper::configuration & config);
+seqan::hibf::layout::layout
+determine_best_number_of_technical_bins(chopper::configuration & config,
+                                        std::vector<size_t> const & kmer_counts,
+                                        std::vector<seqan::hibf::sketch::hyperloglog> const & sketches);
 
 }

--- a/src/layout/determine_best_number_of_technical_bins.cpp
+++ b/src/layout/determine_best_number_of_technical_bins.cpp
@@ -28,8 +28,10 @@
 namespace chopper::layout
 {
 
-std::pair<seqan::hibf::layout::layout, std::vector<seqan::hibf::sketch::hyperloglog>>
-determine_best_number_of_technical_bins(chopper::configuration & config)
+seqan::hibf::layout::layout
+determine_best_number_of_technical_bins(chopper::configuration & config,
+                                        std::vector<size_t> const & kmer_counts,
+                                        std::vector<seqan::hibf::sketch::hyperloglog> const & sketches)
 {
     seqan::hibf::layout::layout best_layout;
 
@@ -65,17 +67,10 @@ determine_best_number_of_technical_bins(chopper::configuration & config)
     size_t best_t_max{};
     size_t t_max_64_memory{};
 
-    std::vector<size_t> kmer_counts;
-    std::vector<seqan::hibf::sketch::hyperloglog> sketches;
-
     for (size_t const t_max : potential_t_max)
     {
         config.hibf_config.tmax = t_max;
 
-        kmer_counts.clear();
-        sketches.clear();
-
-        seqan::hibf::sketch::compute_sketches(config.hibf_config, kmer_counts, sketches);
         seqan::hibf::layout::layout tmp_layout =
             seqan::hibf::layout::compute_layout(config.hibf_config, kmer_counts, sketches);
 
@@ -100,7 +95,7 @@ determine_best_number_of_technical_bins(chopper::configuration & config)
     file_out << "# Best t_max (regarding expected query runtime): " << best_t_max << '\n';
     config.hibf_config.tmax = best_t_max;
 
-    return {best_layout, sketches};
+    return best_layout;
 }
 
 } // namespace chopper::layout

--- a/src/layout/execute.cpp
+++ b/src/layout/execute.cpp
@@ -61,23 +61,23 @@ int execute(chopper::configuration & config, std::vector<std::vector<std::string
 
     seqan::hibf::layout::layout hibf_layout;
     std::vector<seqan::hibf::sketch::hyperloglog> sketches;
+    std::vector<size_t> kmer_counts;
 
     seqan::hibf::concurrent_timer compute_sketches_timer{};
     seqan::hibf::concurrent_timer union_estimation_timer{};
     seqan::hibf::concurrent_timer rearrangement_timer{};
     seqan::hibf::concurrent_timer dp_algorithm_timer{};
 
+    compute_sketches_timer.start();
+    seqan::hibf::sketch::compute_sketches(config.hibf_config, kmer_counts, sketches);
+    compute_sketches_timer.stop();
+
     if (config.determine_best_tmax)
     {
-        std::tie(hibf_layout, sketches) = determine_best_number_of_technical_bins(config);
+        hibf_layout = determine_best_number_of_technical_bins(config, kmer_counts, sketches);
     }
     else
     {
-        std::vector<size_t> kmer_counts;
-
-        compute_sketches_timer.start();
-        seqan::hibf::sketch::compute_sketches(config.hibf_config, kmer_counts, sketches);
-        compute_sketches_timer.stop();
         dp_algorithm_timer.start();
         hibf_layout = seqan::hibf::layout::compute_layout(config.hibf_config,
                                                           kmer_counts,


### PR DESCRIPTION
This will also simplify to later on read sketches from a file instead of computing them.