### PR TITLE
[FIX] Ignore bogus linker error in sanitizer

### DIFF
--- a/.github/workflows/ci_sanitizer.yml
+++ b/.github/workflows/ci_sanitizer.yml
@@ -48,7 +48,7 @@ jobs:
 
           - name: "UBSan"
             os: ubuntu-latest
-            cxx_flags: "-fno-omit-frame-pointer -fsanitize=undefined,float-divide-by-zero -Wno-interference-size"
+            cxx_flags: "-fno-omit-frame-pointer -fsanitize=undefined,float-divide-by-zero -Wno-stringop-overflow -Wno-interference-size"
 
           - name: "UBSan"
             os: macos-14


### PR DESCRIPTION
strinop-overflow in sharg/detail/format_base.hpp:530 while linking display_layout on UBSan Release ubuntu-latest