### PR TITLE
[FIX,DOC] Fix warning output for differing kmer sizes.

### DIFF
--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -41,7 +41,7 @@ void validate_configuration(sharg::parser & parser,
             "[WARNING] Given k-mer size (",
             config.k,
             ") differs from k-mer size in the sketch file (",
-            config.k,
+            sketch_config.k,
             "). The results may be suboptimal. If this was a conscious decision, you can ignore this warning.\n");
     }
 }

--- a/test/cli/cli_chopper_layout_from_sketch_file.cpp
+++ b/test/cli/cli_chopper_layout_from_sketch_file.cpp
@@ -150,7 +150,7 @@ TEST_F(cli_test, chopper_layout_from_sketch_file)
     EXPECT_EQ(result2.out, std::string{});
     EXPECT_EQ(
         result2.err,
-        std::string{"[WARNING] Given k-mer size (20) differs from k-mer size in the sketch file (20). The results may "
+        std::string{"[WARNING] Given k-mer size (20) differs from k-mer size in the sketch file (19). The results may "
                     "be suboptimal. If this was a conscious decision, you can ignore this warning.\n"});
 
     cli_test_result result3 = execute_app("chopper",


### PR DESCRIPTION
I actually run into that warning and was confused :D turned out to be a doc-bug