### PR TITLE
[UTIL,FEATURE] display_layout: Also compute FPR corrected sizes.

### DIFF
--- a/test/cli/util_display_layout_test.cpp
+++ b/test/cli/util_display_layout_test.cpp
@@ -120,12 +120,13 @@ TEST_F(cli_test, display_layout_general)
 
     ASSERT_TRUE(std::filesystem::exists(general_filename));
 
-    std::string expected_general_file{"# Layout: " + layout_filename.string() + "\n" +
-                                      R"(tb_index	exact_size	estimated_size	shared_size	ub_count	kind	splits
-0	479	483	0	2	merged	1
-1	466	466	0	1	split	1
-2	287	289	0	1	split	2
-3	287	289	0	1	split	0
+    std::string expected_general_file{
+        "# Layout: " + layout_filename.string() + "\n" +
+        R"(tb_index	exact_size	estimated_size	fpr_corrected_size	shared_size	ub_count	kind	splits
+0	479	483	153	0	2	merged	1
+1	466	466	466	0	1	split	1
+2	287	289	420	0	1	split	2
+3	287	289	420	0	1	split	0
 )"};
 
     std::string const actual_file{string_from_file(general_filename)};
@@ -164,12 +165,13 @@ TEST_F(cli_test, display_layout_general_with_shared_kmers)
 
     ASSERT_TRUE(std::filesystem::exists(general_filename));
 
-    std::string expected_general_file{"# Layout: " + layout_filename.string() + "\n" +
-                                      R"(tb_index	exact_size	estimated_size	shared_size	ub_count	kind	splits
-0	479	483	371	2	merged	1
-1	466	466	0	1	split	1
-2	287	289	0	1	split	2
-3	287	289	0	1	split	0
+    std::string expected_general_file{
+        "# Layout: " + layout_filename.string() + "\n" +
+        R"(tb_index	exact_size	estimated_size	fpr_corrected_size	shared_size	ub_count	kind	splits
+0	479	483	153	371	2	merged	1
+1	466	466	466	0	1	split	1
+2	287	289	420	0	1	split	2
+3	287	289	420	0	1	split	0
 )"};
 
     std::string const actual_file{string_from_file(general_filename)};


### PR DESCRIPTION
I had a case with a few merged bins within several single bins.

The current display layout looked like this: 

[default.layoutsub171.layout.sizes.general.pdf](https://github.com/user-attachments/files/17473475/default.layoutsub171.layout.sizes.general.pdf)

Which is not really the actual case. Merged bins are size corrected with the relaxed FPR within the DP while split bins are corrected for multiple testing. I incoorporated this into display_layout. Now it looks like this:

[default.layoutsub171.layout.new.general.pdf](https://github.com/user-attachments/files/17473503/default.layoutsub171.layout.new.general.pdf)

which makes more sense for a result of the DP algorithm.
