### PR TITLE
[FIX] Overwrite kmer and window configuration from sketch file to current config.

### DIFF
--- a/src/chopper_layout.cpp
+++ b/src/chopper_layout.cpp
@@ -57,7 +57,7 @@ void validate_configuration(sharg::parser & parser,
         config.k = sketch_config.k; // make sure default is overwritten
     }
 
-    if (parser.is_option_set("window") && config.window != sketch_config.window)
+    if (parser.is_option_set("window") && config.window_size != sketch_config.window_size)
     {
         throw sharg::parser_error{"You are using a sketch file as input but want to use a --window size that differs "
                                   "from the one used for sketching. This will result in a layout (and subsequently "
@@ -65,7 +65,7 @@ void validate_configuration(sharg::parser & parser,
     }
     else
     {
-        config.window = sketch_config.window; // make sure default is overwritten
+        config.window_size = sketch_config.window_size; // make sure default is overwritten
     }
 }
 


### PR DESCRIPTION
I just had this use case. 

I created a sketch file with `k=32`, `w=32`.

Then I ran chopper with the sketch file without setting k and w again on the command line (since in the layout I am not re-sketching and besides sketching I do not use `k` and `w`).

I compared some layouts and noticed that my layout file (created as above from a sketch file) stated `k=19`, `w=19`. Now even though the layout shouldn't be influenced, this is wrong for the subsequent build step. Because when building from layout I do not reconfigure k and w. So my index will be built on k=19 and w=19. :(
